### PR TITLE
Fix Mounted Archer, Bow Expert, Crossbow Cavalry, and Crossbow Expert perks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Current Fixes:
 * The Peak Form perk.
 * The Ruler perk.
 * The Reeve perk.
+* The Mounted Archer perk.
+* The Bow Expert perk.
+* The Crossbow Cavalry perk
+* The Crossbow Expert perk
 * Fixes Item Comparison perk-based coloring.
 
 Current Features:

--- a/src/CommunityPatch/Patches/MountedBowPerksPatch.cs
+++ b/src/CommunityPatch/Patches/MountedBowPerksPatch.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Localization;
+
+namespace CommunityPatch.Patches {
+
+  internal class MountedBowPerksPatch : IPatch {
+
+    public bool Applied { get; private set; }
+
+    public static readonly List<PerkObject> _perks
+      = new List<PerkObject> { DefaultPerks.Bow.MountedArcher, DefaultPerks.Riding.BowExpert };
+
+    public bool IsApplicable(Game game)
+      // ReSharper disable once CompareOfFloatsByEqualityOperator
+      => game.GameType as Campaign != null
+          && (game.PlayerTroop as CharacterObject)?.HeroObject != null;
+
+    public void Apply(Game game) {
+
+      Hero hero = (game.PlayerTroop as CharacterObject)?.HeroObject;
+
+      if (_perks.Any(hero.GetPerkValue)) PatchWeapons();
+
+      (game.GameType as Campaign).CampaignBehaviorManager?.AddBehavior(new OnMountedBowPerkAddedBehaviour());
+      
+      Applied = true;
+    }
+
+    public static void PatchWeapons() {      
+      foreach (ItemObject itemObj in Campaign.Current.Items.Where(item => item.ItemType == ItemObject.ItemTypeEnum.Bow)) {
+        typeof(WeaponComponentData).GetProperty("ItemUsage").SetValue(itemObj.PrimaryWeapon, "bow");
+      }
+    }
+  }
+
+  internal class OnMountedBowPerkAddedBehaviour : CampaignBehaviorBase {
+
+    public override void RegisterEvents() {
+      CampaignEvents.PerkOpenedEvent.AddNonSerializedListener(this, (hero, perk) => {
+        if (hero.Equals(Hero.MainHero) && MountedBowPerksPatch._perks.Any(perk.Equals)) {
+          MountedBowPerksPatch.PatchWeapons();
+        }
+      });
+    }
+
+    public override void SyncData(IDataStore dataStore) {
+    }
+  }
+
+}

--- a/src/CommunityPatch/Patches/MountedCrossbowPerksPatch.cs
+++ b/src/CommunityPatch/Patches/MountedCrossbowPerksPatch.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Localization;
+
+namespace CommunityPatch.Patches {
+
+  internal class MountedCrossbowPerksPatch : IPatch {
+
+    public bool Applied { get; private set; }
+
+    public bool IsApplicable(Game game)
+      // ReSharper disable once CompareOfFloatsByEqualityOperator
+      => game.GameType as Campaign != null
+          && (game.PlayerTroop as CharacterObject)?.HeroObject != null;
+
+    public void Apply(Game game) {
+
+      Hero hero = (game.PlayerTroop as CharacterObject)?.HeroObject;
+
+      if (hero.GetPerkValue(DefaultPerks.Crossbow.CrossbowCavalry)) {
+        MountedCrossbowPerksPatch.EnableReloadingOnHorse();
+      }
+      else if (hero.GetPerkValue(DefaultPerks.Riding.CrossbowExpert)) {
+        MountedCrossbowPerksPatch.MakeUsableOnHorse();
+      }
+
+      (game.GameType as Campaign).CampaignBehaviorManager?.AddBehavior(new OnMountedCrossbowPerkAddedBehaviour());
+      
+      Applied = true;
+    }
+
+    public static void EnableReloadingOnHorse() {
+      foreach (ItemObject itemObj in Campaign.Current.Items.Where(item => item.ItemType == ItemObject.ItemTypeEnum.Crossbow)) {
+        itemObj.PrimaryWeapon.WeaponFlags &= ~WeaponFlags.CantReloadOnHorseback;
+      }
+    }
+
+    public static void MakeUsableOnHorse() {      
+      foreach (ItemObject itemObj in Campaign.Current.Items.Where(item => item.ItemType == ItemObject.ItemTypeEnum.Crossbow)) {
+        typeof(WeaponComponentData).GetProperty("ItemUsage").SetValue(itemObj.PrimaryWeapon, "crossbow");
+      }
+    }
+  }
+
+  internal class OnMountedCrossbowPerkAddedBehaviour : CampaignBehaviorBase {
+
+    public override void RegisterEvents() {
+      CampaignEvents.PerkOpenedEvent.AddNonSerializedListener(this, (hero, perk) => {
+        if (hero.Equals(Hero.MainHero)) {
+          if (perk.Equals(DefaultPerks.Crossbow.CrossbowCavalry)) {
+            MountedCrossbowPerksPatch.EnableReloadingOnHorse();
+          } else if (perk.Equals(DefaultPerks.Riding.CrossbowExpert)) {
+            MountedCrossbowPerksPatch.MakeUsableOnHorse();
+          }
+        }
+      });
+    }
+
+    public override void SyncData(IDataStore dataStore) {
+    }
+  }
+
+}


### PR DESCRIPTION
Addresses #10 by overriding flags and usability on the hero adding said perks or on loading while the hero has said perks. Based on my solution from https://www.nexusmods.com/mountandblade2bannerlord/mods/215.