### PR TITLE
Bannerlord perk

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Current Fixes:
 * The Peak Form perk.
 * The Ruler perk.
 * The Reeve perk.
+* The Bannerlord perk.
 * Fixes Item Comparison perk-based coloring.
 
 Current Features:

--- a/src/CommunityPatch/Patches/BannerlordPerkExplainerPatch.cs
+++ b/src/CommunityPatch/Patches/BannerlordPerkExplainerPatch.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches {
+
+  class BannerlordExplainerPatch : IPatch {
+
+    public bool Applied { get; private set; }
+
+    private static readonly MethodInfo TargetMethodInfo = typeof(PartyBase).GetMethod("get_PartySizeLimitExplainer", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+    private static readonly MethodInfo PatchMethodInfo = typeof(BannerlordExplainerPatch).GetMethod(nameof(PartySizeLimitExplainerPatched), BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+    public void Apply(Game game) {
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo,
+        null,
+        new HarmonyMethod(PatchMethodInfo));
+      Applied = true;
+    }
+
+    public bool IsApplicable(Game game) {
+      var patchInfo = Harmony.GetPatchInfo(TargetMethodInfo);
+      if (AlreadyPatchedByOthers(patchInfo))
+        return false;
+
+      var bytes = TargetMethodInfo.GetCilBytes();
+      if (bytes == null) return false;
+
+      var hash = bytes.GetSha256();
+      return hash.SequenceEqual(new byte[] {
+        0x02, 0x3C, 0xD3, 0xE3, 0xF6, 0x5C, 0xC3, 0x74,
+        0x3C, 0x53, 0xA5, 0x9E, 0x17, 0x54, 0x6E, 0x87,
+        0x6A, 0xF3, 0xFE, 0xF8, 0xDF, 0x1A, 0x55, 0xD8,
+        0x1F, 0x83, 0xBB, 0x7A, 0x13, 0xB6, 0x97, 0xFC
+      });
+    }
+
+    private static void PartySizeLimitExplainerPatched(PartyBase __instance, ref StatExplainer __result) {
+      var extra = BannerlordPatch.BannerlordPerkExtra(__instance.LeaderHero);
+      
+      if (extra > 0)
+        __result.AddLine("Bannerlord", extra);
+    }
+
+  }
+
+}

--- a/src/CommunityPatch/Patches/BannerlordPerkPatch.cs
+++ b/src/CommunityPatch/Patches/BannerlordPerkPatch.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches {
+
+  class BannerlordPatch : IPatch {
+
+    public bool Applied { get; private set; }
+
+    private static readonly MethodInfo TargetMethodInfo = typeof(PartyBase).GetMethod("get_PartySizeLimit", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+    private static readonly MethodInfo PatchMethodInfo = typeof(BannerlordPatch).GetMethod(nameof(PartySizeLimitPatched), BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+    public void Apply(Game game) {
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo,
+        null,
+        new HarmonyMethod(PatchMethodInfo));
+      Applied = true;
+    }
+
+    public bool IsApplicable(Game game) {
+      var patchInfo = Harmony.GetPatchInfo(TargetMethodInfo);
+      if (AlreadyPatchedByOthers(patchInfo))
+        return false;
+
+      var bytes = TargetMethodInfo.GetCilBytes();
+      if (bytes == null) return false;
+
+      var hash = bytes.GetSha256();
+      return hash.SequenceEqual(new byte[] {
+        0xAE, 0xF7, 0x29, 0x0C, 0x6D, 0x5D, 0xFD, 0xE2,
+        0x4D, 0x32, 0x24, 0x35, 0x1D, 0x18, 0x3D, 0x8E,
+        0x40, 0x5E, 0xD3, 0xDA, 0x11, 0xC4, 0x31, 0x92,
+        0x6B, 0x75, 0xAA, 0xB5, 0xEC, 0x3B, 0x9F, 0x2F
+      });
+    }
+
+    private static void PartySizeLimitPatched(PartyBase __instance, ref int __result) {
+      if (__instance.LeaderHero != null && __instance.LeaderHero.GetPerkValue(DefaultPerks.Steward.Bannerlord))
+        __result += __instance.LeaderHero.Clan.Settlements.Count() * 2;
+    }
+
+  }
+
+}

--- a/src/CommunityPatch/Patches/BannerlordPerkPatch.cs
+++ b/src/CommunityPatch/Patches/BannerlordPerkPatch.cs
@@ -41,8 +41,14 @@ namespace CommunityPatch.Patches {
     }
 
     private static void PartySizeLimitPatched(PartyBase __instance, ref int __result) {
-      if (__instance.LeaderHero != null && __instance.LeaderHero.GetPerkValue(DefaultPerks.Steward.Bannerlord))
-        __result += __instance.LeaderHero.Clan.Settlements.Count() * 2;
+      __result += BannerlordPerkExtra(__instance.LeaderHero);
+    }
+
+    public static int BannerlordPerkExtra(Hero hero) {
+      if (hero == null || !hero.GetPerkValue(DefaultPerks.Steward.Bannerlord))
+        return 0;
+
+      return hero.Clan.Settlements.Count() * 2;
     }
 
   }


### PR DESCRIPTION
This is a fix for #33 

I split it into two patches - one for the actual party size limit logic and one for the tooltip when you hover over the party size as shown here:

![TaleWorlds MountAndBlade Launcher_aLZa4o97mB](https://user-images.githubusercontent.com/12700623/78698225-4d2e5900-7902-11ea-82b3-921d471f8e55.png)

I postfix PartyBase.get_PartySizeLimit and PartyBase.get_PartySizeLimitExplainer respectively.
In BannerlordPerkExplainerPatch I reuse the method from BannerlordPerkPatch to make it consisent.

Once again we're in the situation on how we want to interpret TaleWorlds wording: 
*+2 party size for each fief that you own*

I opted to go for the approach where the party leader is chosen as the check if the perk is available. Then it uses the party leader current clan and gets all its settlements. This means that any companion or NPC will get benefits of Bannerlord (if they can get the perk at all?). 
All settlements means that the castle/city will give +2 and the attached villages will provide another +2 each. 
Example:
![TaleWorlds MountAndBlade Launcher_9HMZPALbfW](https://user-images.githubusercontent.com/12700623/78698501-bada8500-7902-11ea-8efb-4dc63af46a28.jpg)

There are 6 settlements owned by the clan, so the party leader with the Bannerlord perk will have an extra +12 to its party size limit.

Does that make sense?
