### PR TITLE
Steward Swords As Tribute fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Current Fixes:
 * The Ruler perk.
 * The Reeve perk.
 * The Bannerlord perk.
+* The Swords As Tribute (Steward) perk.
 * Fixes Item Comparison perk-based coloring.
 
 Current Features:

--- a/src/CommunityPatch/Patches/StewardSwordsAsTributeExplainerPatch.cs
+++ b/src/CommunityPatch/Patches/StewardSwordsAsTributeExplainerPatch.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches {
+
+  class StewardSwordsAsTributeExplainerPatch : IPatch {
+
+    public bool Applied { get; private set; }
+
+    private static readonly MethodInfo TargetMethodInfo = typeof(PartyBase).GetMethod("get_PartySizeLimitExplainer", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+    private static readonly MethodInfo PatchMethodInfo = typeof(StewardSwordsAsTributeExplainerPatch).GetMethod(nameof(PartySizeLimitExplainerPatched), BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+    public void Apply(Game game) {
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo,
+        null,
+        new HarmonyMethod(PatchMethodInfo));
+      Applied = true;
+    }
+
+    public bool IsApplicable(Game game) {
+      var patchInfo = Harmony.GetPatchInfo(TargetMethodInfo);
+      if (AlreadyPatchedByOthers(patchInfo))
+        return false;
+
+      var bytes = TargetMethodInfo.GetCilBytes();
+      if (bytes == null) return false;
+
+      var hash = bytes.GetSha256();
+      return hash.SequenceEqual(new byte[] {
+        0x02, 0x3C, 0xD3, 0xE3, 0xF6, 0x5C, 0xC3, 0x74,
+        0x3C, 0x53, 0xA5, 0x9E, 0x17, 0x54, 0x6E, 0x87,
+        0x6A, 0xF3, 0xFE, 0xF8, 0xDF, 0x1A, 0x55, 0xD8,
+        0x1F, 0x83, 0xBB, 0x7A, 0x13, 0xB6, 0x97, 0xFC
+      });
+    }
+
+    private static void PartySizeLimitExplainerPatched(PartyBase __instance, ref StatExplainer __result) {
+      var extra = StewardSwordsAsTributePatch.StewardSwordsAsTributePerkExtra(__instance.LeaderHero);
+
+      if (extra > 0)
+        __result.AddLine("Swords As Tribute", extra);
+    }
+
+  }
+
+}

--- a/src/CommunityPatch/Patches/StewardSwordsAsTributePerkPatch.cs
+++ b/src/CommunityPatch/Patches/StewardSwordsAsTributePerkPatch.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches {
+
+  class StewardSwordsAsTributePatch : IPatch {
+
+    public bool Applied { get; private set; }
+
+    private static readonly MethodInfo TargetMethodInfo = typeof(PartyBase).GetMethod("get_PartySizeLimit", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+    private static readonly MethodInfo PatchMethodInfo = typeof(StewardSwordsAsTributePatch).GetMethod(nameof(PartySizeLimitPatched), BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+    public void Apply(Game game) {
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo,
+        null,
+        new HarmonyMethod(PatchMethodInfo));
+      Applied = true;
+    }
+
+    public bool IsApplicable(Game game) {
+      var patchInfo = Harmony.GetPatchInfo(TargetMethodInfo);
+      if (AlreadyPatchedByOthers(patchInfo))
+        return false;
+
+      var bytes = TargetMethodInfo.GetCilBytes();
+      if (bytes == null) return false;
+
+      var hash = bytes.GetSha256();
+      return hash.SequenceEqual(new byte[] {
+        0xAE, 0xF7, 0x29, 0x0C, 0x6D, 0x5D, 0xFD, 0xE2,
+        0x4D, 0x32, 0x24, 0x35, 0x1D, 0x18, 0x3D, 0x8E,
+        0x40, 0x5E, 0xD3, 0xDA, 0x11, 0xC4, 0x31, 0x92,
+        0x6B, 0x75, 0xAA, 0xB5, 0xEC, 0x3B, 0x9F, 0x2F
+      });
+    }
+
+    private static void PartySizeLimitPatched(PartyBase __instance, ref int __result) {
+      __result += StewardSwordsAsTributePerkExtra(__instance.LeaderHero);
+    }
+
+    public static int StewardSwordsAsTributePerkExtra(Hero hero) {
+      if (hero == null || hero.Clan.Kingdom == null || hero.Clan.Kingdom.RulingClan != hero.Clan || !hero.GetPerkValue(DefaultPerks.Steward.SwordsAsTribute))
+        return 0;
+
+      return Math.Max(0, (hero.Clan.Kingdom.Clans.Count() - 1) * 10); // Remove one becuase Kingdom.Clans includes the ruling clan which is not a vassal.
+    }
+
+  }
+
+}


### PR DESCRIPTION
Fix for #38 
*+10 party size for every vassal*

It properly stacks with the other party size patches.

It checks if the party leader's clan is the ruling clan of the kingdom and gets the count of all clans, excluding itself. Does that make sense? I think that is the vassals. Aka other clans in a kingdom.
