### PR TITLE
Fixed Swords and Tribute to only be applied to rulers

### DIFF
--- a/src/CommunityPatch/Patches/StewardSwordsAsTributePerkPatch.cs
+++ b/src/CommunityPatch/Patches/StewardSwordsAsTributePerkPatch.cs
@@ -66,9 +66,11 @@ namespace CommunityPatch.Patches {
     private static void Postfix(ref int __result, MobileParty party, StatExplainer explanation) {
       var perk = ActivePatch._perk;
       var hero = party.LeaderHero;
-      if (hero == null)
+
+      if (hero == null || hero.Clan?.Kingdom?.RulingClan?.Leader != hero)
         return;
-      if (!(hero?.GetPerkValue(perk) ?? false))
+
+      if (!hero.GetPerkValue(perk))
         return;
 
       var kingdomClans = hero.Clan?.Kingdom?.Clans;


### PR DESCRIPTION
Tested it and looks good now. Fixed because a comment on nexusmods mentioned that it applied even when the player was just a vassal.