### PR TITLE
Reconstruction Perk Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
     * Nourish Settlement
     * Prominence
     * Prosperous Reign
+    * Reconstruction
     * Reeve
     * Ruler
     * Supreme Authority

--- a/src/CommunityPatch/Patches/Perks/Intelligence/Steward/ReconstructionPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Intelligence/Steward/ReconstructionPatch.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Actions;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Localization;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches.Perks.Intelligence.Steward {
+
+  public sealed class ReconstructionPatch : PatchBase<ReconstructionPatch> {
+
+    public override bool Applied { get; protected set; }
+
+    private static readonly MethodInfo TargetMethodInfo = typeof(IncreaseSettlementHealthAction).GetMethod("ApplyInternal", BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+    private static readonly MethodInfo PatchMethodInfo = typeof(ReconstructionPatch).GetMethod(nameof(Prefix), BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+    public override IEnumerable<MethodBase> GetMethodsChecked() {
+      yield return TargetMethodInfo;
+    }
+
+    private PerkObject _perk;
+
+    private static readonly byte[][] Hashes = {
+      new byte[] {
+        // e1.0.10
+        0x28, 0xDC, 0x69, 0xF2, 0xC3, 0xC2, 0x19, 0xBD,
+        0x70, 0x9C, 0x02, 0xD6, 0x76, 0x9D, 0x73, 0xA1,
+        0xF1, 0x01, 0x4F, 0x52, 0x81, 0x3D, 0x93, 0x3C,
+        0xCB, 0x70, 0x31, 0x89, 0xF8, 0xD1, 0x5D, 0x2D
+      }
+    };
+
+    public override void Reset()
+      => _perk = PerkObject.FindFirst(x => x.Name.GetID() == "Fa01e9kY");
+
+    public override void Apply(Game game) {
+      var textObjStrings = TextObject.ConvertToStringList(
+        new List<TextObject> {
+          _perk.Name,
+          _perk.Description
+        }
+      );
+
+      // most of the properties of skills have private setters, yet Initialize is public
+      _perk.Initialize(
+        textObjStrings[0],
+        textObjStrings[1],
+        _perk.Skill,
+        (int) _perk.RequiredSkillValue,
+        _perk.AlternativePerk,
+        _perk.PrimaryRole, 2.0f,
+        _perk.SecondaryRole, _perk.SecondaryBonus,
+        SkillEffect.EffectIncrementType.AddFactor
+      );
+
+      if (Applied) return;
+
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo,
+        postfix: new HarmonyMethod(PatchMethodInfo));
+      Applied = true;
+    }
+
+    public override bool IsApplicable(Game game) {
+      var patchInfo = Harmony.GetPatchInfo(TargetMethodInfo);
+      if (AlreadyPatchedByOthers(patchInfo))
+        return false;
+
+      var hash = TargetMethodInfo.MakeCilSignatureSha256();
+      return hash.MatchesAnySha256(Hashes);
+    }
+
+    // ReSharper disable once InconsistentNaming
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Prefix(Settlement settlement, ref float percentage) {
+      var perk = ActivePatch._perk;
+      var governor = settlement.Town?.Governor;
+      if (governor == null || !governor.GetPerkValue(perk))
+        return;
+
+      percentage *= perk.PrimaryBonus;
+    }
+
+
+  }
+
+}

--- a/src/CommunityPatch/Patches/Perks/Intelligence/Steward/ReconstructionPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Intelligence/Steward/ReconstructionPatch.cs
@@ -62,7 +62,7 @@ namespace CommunityPatch.Patches.Perks.Intelligence.Steward {
       if (Applied) return;
 
       CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo,
-        postfix: new HarmonyMethod(PatchMethodInfo));
+        new HarmonyMethod(PatchMethodInfo));
       Applied = true;
     }
 


### PR DESCRIPTION
Fix for #46 
The amount was ambigious. Neither the description or the perk initialization had a value. The default value passed in for healing is hardcoded in `VillageHealCampaignBehavior.DailyTick` (0.06), so I ended up multiplying this by 2. 
The value could probably be bigger though, this is a 275 skill perk.
I am currently on e1.0.10, so that's the only hash, if anyone is on the beta branch and wants to quickly check if the hash is different, please do.