### PR TITLE
Fix user not being told that FirstPhase story quests fail in 10 years

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
 * Item Comparison perk-based coloring
 * Party Morale bonus being too low for >10 food variety
 * Fixed crash that occurs when the Neutral clan gains a clan tier 
+* Warn user that early story quests will timeout
 
 ### Current Features
 * Enable and Disable the Intro Video

--- a/src/CommunityPatch/CommunityPatch.csproj
+++ b/src/CommunityPatch/CommunityPatch.csproj
@@ -38,6 +38,10 @@
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>
+        <Reference Include="..\..\..\..\Modules\StoryMode\bin\Win64_Shipping_Client\StoryMode*.dll">
+            <HintPath>%(Identity)</HintPath>
+            <Private>False</Private>
+        </Reference>
         <Reference Include="$(PkgLib_Harmony)\lib\net472\0Harmony.dll">
             <HintPath>%(Identity)</HintPath>
             <Private>True</Private>

--- a/src/CommunityPatch/CommunityPatchSubModule.cs
+++ b/src/CommunityPatch/CommunityPatchSubModule.cs
@@ -5,6 +5,8 @@ using System.Reflection;
 using System.Threading;
 using HarmonyLib;
 using JetBrains.Annotations;
+using StoryMode;
+using StoryMode.StoryModePhases;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
@@ -17,6 +19,9 @@ namespace CommunityPatch {
 
   [PublicAPI]
   public partial class CommunityPatchSubModule : MBSubModuleBase {
+    // may need to update this if vanilla's value changes.
+    // vanilla has it in StoryMode.Behaviors.FirstPhaseCampaignBehavior.FirstPhaseTimeLimitInYears
+    private const int FirstPhaseTimeLimitInYears = 10;
 
     internal static CommunityPatchSubModule Current
       => Module.CurrentModule.SubModules.OfType<CommunityPatchSubModule>().FirstOrDefault();
@@ -184,8 +189,71 @@ namespace CommunityPatch {
       base.OnCampaignStart(game, starterObject);
     }
 
+    private static bool IsFirstStoryPhase() {
+      return FirstPhase.Instance != null
+               && SecondPhase.Instance == null;
+    }
+
+    private void InitStoryQuestsTimeoutVisibility(Game game) {
+      if (!(game.GameType is StoryMode.CampaignStoryMode))
+        return;
+
+      CampaignEvents.OnQuestStartedEvent.AddNonSerializedListener(
+        this,
+        new Action<QuestBase>(OnQuestStarted)
+      );
+      foreach (QuestBase quest
+               in Campaign.Current.QuestManager.Quests.ToList<QuestBase>()) {
+        SetStoryVisibleTimeoutIfNeeded(quest);
+      }
+    }
+
+    private static void SetStoryVisibleTimeoutIfNeeded(QuestBase quest) {
+      if (!IsFirstStoryPhase() || !quest.IsSpecialQuest || !quest.IsOngoing)
+        return;
+
+      // set visible timeout to be when vanilla would have (silently) timed out the quest, 
+      // minus a day to make sure the quest doesn't somehow timeout due to vanilla behavior 
+      // before this.
+      CampaignTime newDueTime = FirstPhase.Instance.FirstPhaseStartTime
+                                  + CampaignTime.Years(FirstPhaseTimeLimitInYears)
+                                  - CampaignTime.Days(1);
+      if (quest.QuestDueTime != newDueTime) {
+        quest.ChangeQuestDueTime(newDueTime);
+        ShowNotification(new TextObject("{=!}Quest time remaining was updated."), "event:/ui/notification/quest_update");
+      }
+    }
+
+    private static void ShowNotification(TextObject message, string soundEventPath = "") {
+      InformationManager.AddQuickInformation(message, 0, null, soundEventPath);
+    }
+
+    class NextHourlyTickListener {
+      private Action<QuestBase> _func;
+      private QuestBase _quest;
+
+      public NextHourlyTickListener(Action<QuestBase> func, QuestBase quest) {
+        _func = func;
+        _quest = quest;
+        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(this, OnHourlyTick);
+      }
+
+      private void OnHourlyTick() {
+        _func.Invoke(_quest);
+        CampaignEvents.HourlyTickEvent.ClearListeners(this);
+      }
+    };
+
+    private void OnQuestStarted(QuestBase quest) {
+      // defer our updates until some time has passed, because they depend on whether 
+      // FirstPhase or SecondPhase is active, and story Phase information is only 
+      // updated after all OnQuestStarted handlers have fired.
+      new NextHourlyTickListener(new Action<QuestBase>(SetStoryVisibleTimeoutIfNeeded), quest);
+    }
+
     public override void OnGameInitializationFinished(Game game) {
       ApplyPatches(game);
+      InitStoryQuestsTimeoutVisibility(game);
 
       base.OnGameInitializationFinished(game);
     }

--- a/src/CommunityPatch/CommunityPatchSubModule.cs
+++ b/src/CommunityPatch/CommunityPatchSubModule.cs
@@ -5,8 +5,6 @@ using System.Reflection;
 using System.Threading;
 using HarmonyLib;
 using JetBrains.Annotations;
-using StoryMode;
-using StoryMode.StoryModePhases;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
@@ -19,9 +17,6 @@ namespace CommunityPatch {
 
   [PublicAPI]
   public partial class CommunityPatchSubModule : MBSubModuleBase {
-    // may need to update this if vanilla's value changes.
-    // vanilla has it in StoryMode.Behaviors.FirstPhaseCampaignBehavior.FirstPhaseTimeLimitInYears
-    private const int FirstPhaseTimeLimitInYears = 10;
 
     internal static CommunityPatchSubModule Current
       => Module.CurrentModule.SubModules.OfType<CommunityPatchSubModule>().FirstOrDefault();
@@ -189,71 +184,8 @@ namespace CommunityPatch {
       base.OnCampaignStart(game, starterObject);
     }
 
-    private static bool IsFirstStoryPhase() {
-      return FirstPhase.Instance != null
-               && SecondPhase.Instance == null;
-    }
-
-    private void InitStoryQuestsTimeoutVisibility(Game game) {
-      if (!(game.GameType is StoryMode.CampaignStoryMode))
-        return;
-
-      CampaignEvents.OnQuestStartedEvent.AddNonSerializedListener(
-        this,
-        new Action<QuestBase>(OnQuestStarted)
-      );
-      foreach (QuestBase quest
-               in Campaign.Current.QuestManager.Quests.ToList<QuestBase>()) {
-        SetStoryVisibleTimeoutIfNeeded(quest);
-      }
-    }
-
-    private static void SetStoryVisibleTimeoutIfNeeded(QuestBase quest) {
-      if (!IsFirstStoryPhase() || !quest.IsSpecialQuest || !quest.IsOngoing)
-        return;
-
-      // set visible timeout to be when vanilla would have (silently) timed out the quest, 
-      // minus a day to make sure the quest doesn't somehow timeout due to vanilla behavior 
-      // before this.
-      CampaignTime newDueTime = FirstPhase.Instance.FirstPhaseStartTime
-                                  + CampaignTime.Years(FirstPhaseTimeLimitInYears)
-                                  - CampaignTime.Days(1);
-      if (quest.QuestDueTime != newDueTime) {
-        quest.ChangeQuestDueTime(newDueTime);
-        ShowNotification(new TextObject("{=!}Quest time remaining was updated."), "event:/ui/notification/quest_update");
-      }
-    }
-
-    private static void ShowNotification(TextObject message, string soundEventPath = "") {
-      InformationManager.AddQuickInformation(message, 0, null, soundEventPath);
-    }
-
-    class NextHourlyTickListener {
-      private Action<QuestBase> _func;
-      private QuestBase _quest;
-
-      public NextHourlyTickListener(Action<QuestBase> func, QuestBase quest) {
-        _func = func;
-        _quest = quest;
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(this, OnHourlyTick);
-      }
-
-      private void OnHourlyTick() {
-        _func.Invoke(_quest);
-        CampaignEvents.HourlyTickEvent.ClearListeners(this);
-      }
-    };
-
-    private void OnQuestStarted(QuestBase quest) {
-      // defer our updates until some time has passed, because they depend on whether 
-      // FirstPhase or SecondPhase is active, and story Phase information is only 
-      // updated after all OnQuestStarted handlers have fired.
-      new NextHourlyTickListener(new Action<QuestBase>(SetStoryVisibleTimeoutIfNeeded), quest);
-    }
-
     public override void OnGameInitializationFinished(Game game) {
       ApplyPatches(game);
-      InitStoryQuestsTimeoutVisibility(game);
 
       base.OnGameInitializationFinished(game);
     }

--- a/src/CommunityPatch/Patches/EarlyStoryVisibleTimeoutPatch.cs
+++ b/src/CommunityPatch/Patches/EarlyStoryVisibleTimeoutPatch.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using StoryMode;
+using StoryMode.Behaviors;
+using StoryMode.StoryModePhases;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Localization;
+
+namespace CommunityPatch.Patches {
+
+  public sealed class EarlyStoryVisibleTimeoutPatch : IPatch {
+    // default if we can't obtain vanilla's value
+    private const int DefaultFirstPhaseTimeLimitInYears = 10;
+    private readonly int FirstPhaseTimeLimitInYears;
+
+    public EarlyStoryVisibleTimeoutPatch() {
+      FirstPhaseTimeLimitInYears = ExtractFirstPhaseTimeLimitInYears();
+    }
+
+    public bool Applied { get; private set; }
+
+    public void Reset() {
+      if (Applied) {
+        CampaignEvents.OnQuestStartedEvent.ClearListeners(this);
+        Applied = false;
+      }
+    }
+
+    public bool? IsApplicable(Game game) => game.GameType is StoryMode.CampaignStoryMode;
+
+    public IEnumerable<MethodBase> GetMethodsChecked() {
+      yield break;
+    }
+
+    private static int ExtractFirstPhaseTimeLimitInYears() {
+      try {
+        FieldInfo field = typeof(FirstPhaseCampaignBehavior).GetField("FirstPhaseTimeLimitInYears", BindingFlags.NonPublic | BindingFlags.Static);
+        return (int)field.GetRawConstantValue();
+      }
+      catch (NullReferenceException ex) {
+        // couldn't locate the field in vanilla. Maybe the name has changed, or it's access modifiers.
+        CommunityPatchSubModule.Error(ex, $"{typeof(EarlyStoryVisibleTimeoutPatch).Name}: Couldn't locate vanilla's timeout value." + Environment.NewLine);
+      }
+      return DefaultFirstPhaseTimeLimitInYears;
+    }
+
+    public void Apply(Game game) {
+      CampaignEvents.OnQuestStartedEvent.AddNonSerializedListener(
+        this,
+        new Action<QuestBase>(OnQuestStarted)
+      );
+      foreach (QuestBase quest
+               in Campaign.Current.QuestManager.Quests.ToList<QuestBase>()) {
+        SetStoryVisibleTimeoutIfNeeded(quest);
+      }
+
+      Applied = true;
+    }
+
+    private static bool IsFirstStoryPhase() {
+      return FirstPhase.Instance != null
+               && SecondPhase.Instance == null;
+    }
+
+    private void SetStoryVisibleTimeoutIfNeeded(QuestBase quest) {
+      if (!IsFirstStoryPhase() || !quest.IsSpecialQuest || !quest.IsOngoing)
+        return;
+
+      // set visible timeout to be when vanilla would have (silently) timed 
+      // out the quest,  minus a day to make very sure the quest doesn't 
+      // somehow trigger vanilla's silent timeout too early.
+      CampaignTime newDueTime = FirstPhase.Instance.FirstPhaseStartTime
+                                  + CampaignTime.Years(FirstPhaseTimeLimitInYears)
+                                  - CampaignTime.Days(1);
+      if (quest.QuestDueTime != newDueTime) {
+        quest.ChangeQuestDueTime(newDueTime);
+        ShowNotification(new TextObject("{=!}Quest time remaining was updated."), "event:/ui/notification/quest_update");
+      }
+    }
+
+    private static void ShowNotification(TextObject message, string soundEventPath = "") {
+      InformationManager.AddQuickInformation(message, 0, null, soundEventPath);
+    }
+
+    class NextHourlyTickListener {
+      private Action<QuestBase> _func;
+      private QuestBase _quest;
+
+      public NextHourlyTickListener(Action<QuestBase> func, QuestBase quest) {
+        _func = func;
+        _quest = quest;
+        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(this, OnHourlyTick);
+      }
+
+      private void OnHourlyTick() {
+        _func.Invoke(_quest);
+        CampaignEvents.HourlyTickEvent.ClearListeners(this);
+      }
+    };
+
+    private void OnQuestStarted(QuestBase quest) {
+      // defer our updates until some time has passed, because they depend on whether 
+      // FirstPhase or SecondPhase is active, and story Phase information is only 
+      // updated after all OnQuestStarted handlers have fired.
+      new NextHourlyTickListener(new Action<QuestBase>(SetStoryVisibleTimeoutIfNeeded), quest);
+    }
+
+  }
+
+}

--- a/src/CommunityPatch/Patches/EarlyStoryVisibleTimeoutPatch.cs
+++ b/src/CommunityPatch/Patches/EarlyStoryVisibleTimeoutPatch.cs
@@ -77,7 +77,7 @@ namespace CommunityPatch.Patches {
                                   - CampaignTime.Days(1);
       if (quest.QuestDueTime != newDueTime) {
         quest.ChangeQuestDueTime(newDueTime);
-        ShowNotification(new TextObject("{=!}Quest time remaining was updated."), "event:/ui/notification/quest_update");
+        ShowNotification(new TextObject("{=QuestTimeRemainingUpdated}Quest time remaining was updated."), "event:/ui/notification/quest_update");
       }
     }
 


### PR DESCRIPTION
Fixes #133 . Now those quests will appear with the days until failure much like other quests.

Unfortunately there's a few hours game time ( 10 seconds or so real life time) until the quests are updated after getting them. See code [comments](https://github.com/Tyler-IN/MnB2-Bannerlord-CommunityPatch/pull/150/commits/0cc24f958e1d111d549891ffe08af49e0f40ae94#diff-4cb347780d4b8f8827fabdb6f694148dR105).