### PR TITLE
fix land grants for veteran patch hash check

### DIFF
--- a/src/CommunityPatch/Patches/Policies/LandGrantsForVeteransPatch.cs
+++ b/src/CommunityPatch/Patches/Policies/LandGrantsForVeteransPatch.cs
@@ -86,7 +86,7 @@ namespace CommunityPatch.Patches.Policies {
       if (AlreadyPatchedByOthers(patchInfo2))
         return false;
 
-      var hash2 = TargetMethodInfo1.MakeCilSignatureSha256();
+      var hash2 = TargetMethodInfo2.MakeCilSignatureSha256();
       return hash2.MatchesAnySha256(Hashes2);
     }
     


### PR DESCRIPTION
Typo causing a wrong hash check :

![alt text](https://cdn.discordapp.com/attachments/700320262784024590/700868003935551498/Patch_loading.png)