### PR TITLE
Make project easier to build for new people

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+
+    <PropertyGroup>
+        <MnB2BannerlordBinDir>../../../../bin/Win64_Shipping_Client</MnB2BannerlordBinDir>
+        <MnB2BannerlordLauncher>$(MnB2BannerlordBinDir)/TaleWorlds.MountAndBlade.Launcher.exe</MnB2BannerlordLauncher>
+    </PropertyGroup>
+
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,8 @@
 
         <!-- and not these -->
         <MnB2BannerlordBinDir>$(MnB2BannerlordDir)/bin/Win64_Shipping_Client</MnB2BannerlordBinDir>
-        <MnB2BannerlordLauncher>$(MnB2BannerlordBinDir)/TaleWorlds.MountAndBlade.Launcher.exe</MnB2BannerlordLauncher>
+        <MnB2BannerlordLauncherName>TaleWorlds.MountAndBlade.Launcher.exe</MnB2BannerlordLauncherName>
+        <MnB2BannerlordLauncher>$(MnB2BannerlordBinDir)/$(MnB2BannerlordLauncherName)</MnB2BannerlordLauncher>
     </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,11 @@
 <Project>
 
     <PropertyGroup>
-        <MnB2BannerlordBinDir>../../../../bin/Win64_Shipping_Client</MnB2BannerlordBinDir>
+        <!-- user changes this -->
+        <MnB2BannerlordDir>../../../..</MnB2BannerlordDir>
+
+        <!-- and not these -->
+        <MnB2BannerlordBinDir>$(MnB2BannerlordDir)/bin/Win64_Shipping_Client</MnB2BannerlordBinDir>
         <MnB2BannerlordLauncher>$(MnB2BannerlordBinDir)/TaleWorlds.MountAndBlade.Launcher.exe</MnB2BannerlordLauncher>
     </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This repo should be placed under the Modules folder in your Bannerlord installat
 
 The default location for Bannerlord is `C:\Program Files (x86)\Steam\steamapps\common\Mount & Blade II Bannerlord`.
 
-If your Bannerlord or local repo are in a different place, you can change the property MnB2BannerlordBinDir in Directory.Build.props to the `bin/Win64_Shipping_Client` folder under your Bannerlord install. When editing the file be sure to use `&amp;` in place of an `&` if the path has one.
+If your Bannerlord or local repo are in a different place, you can change the property MnB2BannerlordDir in Directory.Build.props to your bannerlord install. When editing the file be sure to use `&amp;` in place of an `&` if the path has one.
 
 ## Credits
 ##### Contributors

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ Bannerlord Mod.IO: https://bannerlord.mod.io/community-patch
 
 ## Building
 
-Just open the \*.sln in Visual Studio and build normally. You will probably need to change the variable MnB2BannerlordBinDir in the \*.csproj file to the `bin\Win64_Shipping_Client` folder under your bannerlord installation. If editing the file directly the standard location is `C:\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\bin\Win64_Shipping_Client`
+This repo should be placed under the Modules folder in your Bannerlord installation, and it will build out-of-the-box. Just open the \*.sln in Visual Studio and build normally.
+
+The default location for Bannerlord is `C:\Program Files (x86)\Steam\steamapps\common\Mount & Blade II Bannerlord`.
 
 ## Credits
 ##### Contributors

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ NexusMods: https://www.nexusmods.com/mountandblade2bannerlord/mods/186
 
 Bannerlord Mod.IO: https://bannerlord.mod.io/community-patch
 
+## Building
+
+Just open the \*.sln in Visual Studio and build normally. You will probably need to change the variable MnB2BannerlordBinDir in the \*.csproj file to the `bin\Win64_Shipping_Client` folder under your bannerlord installation. If editing the file directly the standard location is `C:\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\bin\Win64_Shipping_Client`
+
 ## Credits
 ##### Contributors
 * [🅠](https://www.nexusmods.com/users/958353) ([Discord](https://discordapp.com/users/475636674076868618))

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ This repo should be placed under the Modules folder in your Bannerlord installat
 
 The default location for Bannerlord is `C:\Program Files (x86)\Steam\steamapps\common\Mount & Blade II Bannerlord`.
 
+If your Bannerlord or local repo are in a different place, you can change the property MnB2BannerlordBinDir in Directory.Build.props to the `bin/Win64_Shipping_Client` folder under your Bannerlord install. When editing the file be sure to use `&amp;` in place of an `&` if the path has one.
+
 ## Credits
 ##### Contributors
 * [🅠](https://www.nexusmods.com/users/958353) ([Discord](https://discordapp.com/users/475636674076868618))

--- a/src/CommunityPatch/CommunityPatch.csproj
+++ b/src/CommunityPatch/CommunityPatch.csproj
@@ -39,7 +39,7 @@
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="$(MnB2BannerlordBinDir)\..\..\Modules\StoryMode\bin\Win64_Shipping_Client\StoryMode*.dll">
+        <Reference Include="$(MnB2BannerlordDir)\Modules\StoryMode\bin\Win64_Shipping_Client\StoryMode*.dll">
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>

--- a/src/CommunityPatch/CommunityPatch.csproj
+++ b/src/CommunityPatch/CommunityPatch.csproj
@@ -25,23 +25,23 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Reference Include="..\..\..\..\bin\Win64_Shipping_Client\System.*.dll">
+        <Reference Include="$(MnB2BannerlordBinDir)\System.*.dll">
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="..\..\..\..\bin\Win64_Shipping_Client\TaleWorlds.*.dll">
+        <Reference Include="$(MnB2BannerlordBinDir)\TaleWorlds.*.dll">
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="..\..\..\..\bin\Win64_Shipping_Client\Steamworks.*.dll">
+        <Reference Include="$(MnB2BannerlordBinDir)\Steamworks.*.dll">
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="..\..\..\..\bin\Win64_Shipping_Client\Mono.*.dll">
+        <Reference Include="$(MnB2BannerlordBinDir)\Mono.*.dll">
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="..\..\..\..\Modules\StoryMode\bin\Win64_Shipping_Client\StoryMode*.dll">
+        <Reference Include="$(MnB2BannerlordBinDir)\..\..\Modules\StoryMode\bin\Win64_Shipping_Client\StoryMode*.dll">
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>

--- a/src/CommunityPatch/CommunityPatch.csproj
+++ b/src/CommunityPatch/CommunityPatch.csproj
@@ -14,8 +14,6 @@
         <OutputPath>../../bin/Win64_Shipping_Client</OutputPath>
         <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
         <LangVersion>8</LangVersion>
-        <MnB2BannerlordBinDir>../../../../bin/Win64_Shipping_Client</MnB2BannerlordBinDir>
-        <MnB2BannerlordLauncher>$(MnB2BannerlordBinDir)/TaleWorlds.MountAndBlade.Launcher.exe</MnB2BannerlordLauncher>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/Tyler-IN/MnB2-Bannerlord-CommunityPatch</RepositoryUrl>

--- a/src/CommunityPatch/Properties/launchSettings.json
+++ b/src/CommunityPatch/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "M&B II: BL": {
       "commandName": "Executable",
-      "executablePath": "$(MnB2BannerlordLauncher)",
-      "workingDirectory": "$(MnB2BannerlordDir)"
+      "executablePath": "./$(MnB2BannerlordLauncherName)",
+      "workingDirectory": "$(MnB2BannerlordBinDir)"
     }
   }
 }

--- a/tools/Antijank/Antijank.csproj
+++ b/tools/Antijank/Antijank.csproj
@@ -6,26 +6,27 @@
         <Platforms>x64</Platforms>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>8</LangVersion>
+        <MnB2BannerlordBinDir>../../../../bin/Win64_Shipping_Client</MnB2BannerlordBinDir>
     </PropertyGroup>
 
     <ItemGroup>
-        <Reference Include="..\..\..\..\bin\Win64_Shipping_Client\System.*.dll">
+        <Reference Include="$(MnB2BannerlordBinDir)\System.*.dll">
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="..\..\..\..\bin\Win64_Shipping_Client\TaleWorlds.*.dll">
+        <Reference Include="$(MnB2BannerlordBinDir)\TaleWorlds.*.dll">
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="..\..\..\..\bin\Win64_Shipping_Client\TaleWorlds.MountAndBlade.Launcher.exe">
+        <Reference Include="$(MnB2BannerlordBinDir)\TaleWorlds.MountAndBlade.Launcher.exe">
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="..\..\..\..\bin\Win64_Shipping_Client\Steamworks.*.dll">
+        <Reference Include="$(MnB2BannerlordBinDir)\Steamworks.*.dll">
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="..\..\..\..\bin\Win64_Shipping_Client\Mono.*.dll">
+        <Reference Include="$(MnB2BannerlordBinDir)\Mono.*.dll">
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>
@@ -57,6 +58,6 @@
             <FilesToCopy Include="$(OutputPath)\*.*" />
         </ItemGroup>
         <Message Importance="high" Text="Copying: @(FilesToCopy)" />
-        <Copy UseHardlinksIfPossible="true" SourceFiles="@(FilesToCopy)" DestinationFolder="..\..\..\..\bin\Win64_Shipping_Client\" OverwriteReadOnlyFiles="true" SkipUnchangedFiles="true" />
+        <Copy UseHardlinksIfPossible="true" SourceFiles="@(FilesToCopy)" DestinationFolder="$(MnB2BannerlordBinDir)" OverwriteReadOnlyFiles="true" SkipUnchangedFiles="true" />
     </Target>
 </Project>

--- a/tools/Antijank/Antijank.csproj
+++ b/tools/Antijank/Antijank.csproj
@@ -6,7 +6,6 @@
         <Platforms>x64</Platforms>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>8</LangVersion>
-        <MnB2BannerlordBinDir>../../../../bin/Win64_Shipping_Client</MnB2BannerlordBinDir>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tools/GeneratePatchTargetHashes/GeneratePatchTargetHashes.csproj
+++ b/tools/GeneratePatchTargetHashes/GeneratePatchTargetHashes.csproj
@@ -8,22 +8,23 @@
         <Configurations>Release;Debug</Configurations>
         <Platforms>x64</Platforms>
         <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
+        <MnB2BannerlordBinDir>../../../../bin/Win64_Shipping_Client</MnB2BannerlordBinDir>
     </PropertyGroup>
 
     <ItemGroup>
-        <Reference Include="..\..\..\..\bin\Win64_Shipping_Client\System.*.dll">
+        <Reference Include="$(MnB2BannerlordBinDir)\System.*.dll">
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="..\..\..\..\bin\Win64_Shipping_Client\TaleWorlds.*.dll">
+        <Reference Include="$(MnB2BannerlordBinDir)\TaleWorlds.*.dll">
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="..\..\..\..\bin\Win64_Shipping_Client\Steamworks.*.dll">
+        <Reference Include="$(MnB2BannerlordBinDir)\Steamworks.*.dll">
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="..\..\..\..\bin\Win64_Shipping_Client\Mono.*.dll">
+        <Reference Include="$(MnB2BannerlordBinDir)\Mono.*.dll">
             <HintPath>%(Identity)</HintPath>
             <Private>False</Private>
         </Reference>

--- a/tools/GeneratePatchTargetHashes/GeneratePatchTargetHashes.csproj
+++ b/tools/GeneratePatchTargetHashes/GeneratePatchTargetHashes.csproj
@@ -8,7 +8,6 @@
         <Configurations>Release;Debug</Configurations>
         <Platforms>x64</Platforms>
         <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
-        <MnB2BannerlordBinDir>../../../../bin/Win64_Shipping_Client</MnB2BannerlordBinDir>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tools/UnblockFile/UnblockFile.csproj
+++ b/tools/UnblockFile/UnblockFile.csproj
@@ -6,7 +6,6 @@
         <PlatformTarget>x64</PlatformTarget>
         <Configurations>Release;Debug</Configurations>
         <Platforms>x64</Platforms>
-        <MnB2BannerlordBinDir>../../../../bin/Win64_Shipping_Client</MnB2BannerlordBinDir>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tools/UnblockFile/UnblockFile.csproj
+++ b/tools/UnblockFile/UnblockFile.csproj
@@ -6,11 +6,12 @@
         <PlatformTarget>x64</PlatformTarget>
         <Configurations>Release;Debug</Configurations>
         <Platforms>x64</Platforms>
+        <MnB2BannerlordBinDir>../../../../bin/Win64_Shipping_Client</MnB2BannerlordBinDir>
     </PropertyGroup>
 
     <ItemGroup>
       <Reference Include="TaleWorlds.MountAndBlade, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>..\..\..\..\bin\Win64_Shipping_Client\TaleWorlds.MountAndBlade.dll</HintPath>
+        <HintPath>$(MnB2BannerlordBinDir)\TaleWorlds.MountAndBlade.dll</HintPath>
       </Reference>
     </ItemGroup>
 


### PR DESCRIPTION
Updates the readme to tell people the intended place for the repo. (the Modules dir).

Also reduce repetition in \*.csproj files by moving reference etc paths to project properties like 'MnB2BannerlordBinDir' when possible. While it works without this, someday someone might want to build with Bannerlord or the repo somewhere else and this would help them.