### PR TITLE
Good materials perk from engineering tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
   * Engineering
     * Ballistics
     * Construction Expert
+    * Good Materials
 * Policies
   * Land Grants For Veterans
 * Learning Rate explanation

--- a/src/CommunityPatch/FloatHelper.cs
+++ b/src/CommunityPatch/FloatHelper.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace CommunityPatch {
+  public static class FloatHelper {
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsZero(this float value)
+      => Math.Abs(value) < 0.0001f;
+  }
+}

--- a/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/GoodMaterialsPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/GoodMaterialsPatch.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using Helpers;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Localization;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches.Perks.Intelligence.Engineering {
+  public class GoodMaterialsPatch : PatchBase<GoodMaterialsPatch> {
+    public override bool Applied { get; protected set; }
+
+    private static readonly Type MapSiegeProductionVmType = Type.GetType("SandBox.ViewModelCollection.MapSiege.MapSiegeProductionVM, SandBox.ViewModelCollection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
+    
+    private static readonly MethodInfo AiTargetMethodInfo =
+      typeof(SiegeEvent).GetMethod(nameof(SiegeEvent.DoSiegeAction), BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+    
+    private static readonly MethodInfo PlayerTargetMethodInfo = 
+      MapSiegeProductionVmType?.GetMethod("OnPossibleMachineSelection", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+    private static readonly MethodInfo AiPatchMethodInfoPostfix = typeof(GoodMaterialsPatch).GetMethod(nameof(AiPostfix), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+    private static readonly MethodInfo PlayerPatchMethodInfoPostfix = typeof(GoodMaterialsPatch).GetMethod(nameof(PlayerPostfix), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+    private static readonly MethodInfo PlayerPatchMethodInfoPrefix = typeof(GoodMaterialsPatch).GetMethod(nameof(PlayerPrefix), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+    public override IEnumerable<MethodBase> GetMethodsChecked() {
+      yield return AiTargetMethodInfo;
+      yield return PlayerTargetMethodInfo;
+    }
+    public override void Reset()
+      => _perk = PerkObject.FindFirst(x => x.Name.GetID() == "EJCrymMr");
+    
+    private PerkObject _perk;
+
+    private static readonly byte[][] AiHashes = {
+      new byte[] {
+        // e1.1.0.225190
+        0x27, 0x47, 0x64, 0x00, 0xA1, 0x01, 0x5C, 0x6B,
+        0xDF, 0x91, 0x21, 0x34, 0xD6, 0x97, 0x63, 0x11,
+        0x5D, 0xF1, 0x1D, 0xA9, 0x64, 0x6B, 0xB6, 0x11,
+        0x2D, 0x7C, 0x3F, 0xF2, 0xE6, 0xF3, 0x70, 0xAE
+      }
+    };
+    
+    private static readonly byte[][] PlayerHashes = {
+      new byte[] {
+        // e1.1.0.225190
+        0x6A, 0x17, 0x74, 0xF3, 0xA5, 0xF0, 0xCC, 0x28,
+        0xD4, 0x9D, 0xE8, 0x07, 0xB4, 0x29, 0x5F, 0xA4,
+        0x19, 0xB3, 0x35, 0x68, 0xF5, 0xA7, 0xCB, 0xDD,
+        0x1D, 0xD0, 0xCA, 0x8C, 0xDE, 0x57, 0xD5, 0xA5
+      }
+    };
+    
+    public override bool? IsApplicable(Game game)
+      // ReSharper disable once CompareOfFloatsByEqualityOperator
+    {
+      if (_perk == null) return false;
+      if (_perk.PrimaryBonus != 0.3f) return false;
+      if (PlayerTargetMethodInfo == null) return false;
+      
+      var aiPatchInfo = Harmony.GetPatchInfo(AiTargetMethodInfo);
+      if (AlreadyPatchedByOthers(aiPatchInfo)) return false;
+      
+      var playerPatchInfo = Harmony.GetPatchInfo(PlayerTargetMethodInfo);
+      if (AlreadyPatchedByOthers(playerPatchInfo)) return false;
+
+      var aiHash = AiTargetMethodInfo.MakeCilSignatureSha256();
+      var playerHash = PlayerTargetMethodInfo.MakeCilSignatureSha256();
+      return aiHash.MatchesAnySha256(AiHashes) && playerHash.MatchesAnySha256(PlayerHashes);
+    }
+    
+    public override void Apply(Game game) {
+      var textObjStrings = TextObject.ConvertToStringList(
+        new List<TextObject> {
+          _perk.Name,
+          _perk.Description
+        }
+      );
+      
+      _perk.Initialize(
+        textObjStrings[0],
+        textObjStrings[1],
+        _perk.Skill,
+        (int) _perk.RequiredSkillValue,
+        _perk.AlternativePerk,
+        _perk.PrimaryRole, 20f,
+        _perk.SecondaryRole, _perk.SecondaryBonus,
+        _perk.IncrementType
+      );
+      if (Applied) return;
+
+      CommunityPatchSubModule.Harmony.Patch(AiTargetMethodInfo, postfix: new HarmonyMethod(AiPatchMethodInfoPostfix));
+      CommunityPatchSubModule.Harmony.Patch(PlayerTargetMethodInfo, postfix: new HarmonyMethod(PlayerPatchMethodInfoPostfix));
+      CommunityPatchSubModule.Harmony.Patch(PlayerTargetMethodInfo, new HarmonyMethod(PlayerPatchMethodInfoPrefix));
+
+      Applied = true;
+    }
+    
+    // ReSharper disable once InconsistentNaming
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void AiPostfix(ref SiegeEvent __instance, SiegeEvent.SiegeEnginesContainer siegeEngines, SiegeStrategyActionModel.SiegeAction siegeAction, SiegeEngineType siegeEngineType, int deploymentIndex, int reserveIndex) {
+      if (siegeAction != SiegeStrategyActionModel.SiegeAction.ConstructNewSiegeEngine) return;
+
+      var deployedSiegeEngines = siegeEngines.DeployedSiegeEngines;
+      var justDeployedEngine = deployedSiegeEngines.LastOrDefault();
+      if (justDeployedEngine == null) return;
+
+      var sideSiegeEvent = GetSiegeContainerSide(__instance, siegeEngines);
+      ApplyPerkToSiegeEngine(justDeployedEngine, sideSiegeEvent);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    // ReSharper disable once RedundantAssignment
+    public static void PlayerPrefix(ref Object __instance, ref Tuple<int, int> __state) {
+      var siegeEvent = GetSiegeEventFromVm(__instance);
+      var playerSideSiegeEvent = siegeEvent.GetSiegeEventSide(GetPlayerSideFromVm(__instance));
+      var deployedSiegeEngineCount = playerSideSiegeEvent.SiegeEngines.DeployedSiegeEngines.Count;
+      var reservedSiegeEngineCount = playerSideSiegeEvent.SiegeEngines.ReservedSiegeEngines.Count;
+      __state = new Tuple<int, int>(deployedSiegeEngineCount, reservedSiegeEngineCount);
+    }
+    
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void PlayerPostfix(ref Object __instance, ref Tuple<int, int> __state) {
+      var siegeEvent = GetSiegeEventFromVm(__instance);
+      var playerSideSiegeEvent = siegeEvent.GetSiegeEventSide(GetPlayerSideFromVm(__instance));
+      
+      if (!HasSiegeEngineJustBeenConstructed(playerSideSiegeEvent, __state.Item1, __state.Item2)) return;
+
+      var justDeployedEngine = playerSideSiegeEvent.SiegeEngines.DeployedSiegeEngines.Last();
+      ApplyPerkToSiegeEngine(justDeployedEngine, playerSideSiegeEvent);
+    }
+
+    private static ISiegeEventSide GetSiegeContainerSide(SiegeEvent siegeEvent, SiegeEvent.SiegeEnginesContainer siegeEngines) 
+      => siegeEvent.GetSiegeEventSide(siegeEvent.BesiegerCamp.SiegeEngines == siegeEngines ? BattleSideEnum.Attacker : BattleSideEnum.Defender);
+    
+    private static void ApplyPerkToSiegeEngine(SiegeEvent.SiegeEngineConstructionProgress justDeployedEngine, ISiegeEventSide sideSiegeEvent)
+    {
+      var perk = ActivePatch._perk;
+      var engineHealth = new ExplainedNumber(justDeployedEngine.Hitpoints);
+
+      foreach (var siegeParty in sideSiegeEvent.SiegeParties.Where(x => x.MobileParty != null))
+        PerkHelper.AddPerkBonusForParty(perk, siegeParty.MobileParty, ref engineHealth);
+
+      justDeployedEngine.SetHitpoints(engineHealth.ResultNumber);
+    }
+    
+    private static SiegeEvent GetSiegeEventFromVm(object vm) {
+      var propertyInfo = MapSiegeProductionVmType.GetProperty("Siege", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+      return (SiegeEvent)propertyInfo?.GetValue(vm);
+    }
+    
+    private static BattleSideEnum GetPlayerSideFromVm(object vm) {
+      var propertyInfo = MapSiegeProductionVmType.GetProperty("PlayerSide", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+      return (BattleSideEnum) (propertyInfo != null ? propertyInfo.GetValue(vm) : BattleSideEnum.None);
+    }
+
+    private static bool HasSiegeEngineJustBeenConstructed(ISiegeEventSide playerSiegeEvent, int deployedSiegeEngineCount, int reservedSiegeEngineCount) {
+      if (playerSiegeEvent.SiegeEngines.DeployedSiegeEngines.Count <= deployedSiegeEngineCount) return false;
+      return playerSiegeEvent.SiegeEngines.ReservedSiegeEngines.Count == reservedSiegeEngineCount;
+    }
+  }
+}

--- a/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/SiegeEngineConstructionExtraDataManager.cs
+++ b/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/SiegeEngineConstructionExtraDataManager.cs
@@ -1,0 +1,33 @@
+using System.Runtime.CompilerServices;
+using TaleWorlds.CampaignSystem;
+
+namespace CommunityPatch.Patches.Perks.Intelligence.Engineering.Stubs {
+
+  public static class SiegeEngineConstructionExtraDataManager {
+    private static readonly ConditionalWeakTable<SiegeEvent.SiegeEngineConstructionProgress, SiegeEngineConstructionData> Links
+      = new ConditionalWeakTable<SiegeEvent.SiegeEngineConstructionProgress, SiegeEngineConstructionData>();
+
+    public static void SetMaxHitPoints(SiegeEvent.SiegeEngineConstructionProgress construction, float maxHp) 
+      => GetDataOrCreate(construction).MaxHitPoints = maxHp;
+    
+    public static float GetMaxHitPoints(SiegeEvent.SiegeEngineConstructionProgress construction)
+      => GetDataOrCreate(construction).MaxHitPoints;
+
+    private static SiegeEngineConstructionData GetDataOrCreate(SiegeEvent.SiegeEngineConstructionProgress construction) {
+      Links.TryGetValue(construction, out var data);
+      return data ?? CreateEmptyData(construction);
+    }
+
+    private static SiegeEngineConstructionData CreateEmptyData(SiegeEvent.SiegeEngineConstructionProgress construction) {
+      var data = new SiegeEngineConstructionData {
+        MaxHitPoints = construction.SiegeEngine.MaxHitPoints
+      };
+      Links.Add(construction, data);
+      return data;
+    }
+  }
+
+  public class SiegeEngineConstructionData {
+    public float MaxHitPoints { get; set; }
+  }
+}

--- a/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/SiegeTooltipHelper.cs
+++ b/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/SiegeTooltipHelper.cs
@@ -46,6 +46,16 @@ namespace CommunityPatch.Patches.Perks.Intelligence.Engineering {
       rangedDamageProperty.ValueLabel = amplifiedRangedDamage.ToString();
     }
     
+    public static void UpdateMaxHpTooltip(List<TooltipProperty> tooltips, float bonusHp)
+    {
+      var property = FindMaxHpTooltipProperty(tooltips);
+      if (property == null) return;
+
+      Double.TryParse(property.ValueLabel, out var currentHp);
+      var buffedHp = (int) (currentHp + bonusHp);
+      property.ValueLabel = buffedHp.ToString();
+    }
+    
     public static void AddPerkTooltip(List<TooltipProperty> tooltips, PerkObject perk, float bonusValue) {
       if (Math.Abs(bonusValue) < 0.05) return;
       var isRate = perk.IncrementType == SkillEffect.EffectIncrementType.AddFactor;
@@ -66,6 +76,9 @@ namespace CommunityPatch.Patches.Perks.Intelligence.Engineering {
     private static TooltipProperty FindRangedDamageTooltipProperty(List<TooltipProperty> tooltips) 
       =>  tooltips.FirstOrDefault(x => 
         x.DefinitionLabel == GameTexts.FindText("str_projectile_damage").ToString());
+
+    private static TooltipProperty FindMaxHpTooltipProperty(List<TooltipProperty> tooltips)
+      => tooltips[3];
   }
 
 }

--- a/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/SiegeTooltipHelper.cs
+++ b/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/SiegeTooltipHelper.cs
@@ -57,7 +57,7 @@ namespace CommunityPatch.Patches.Perks.Intelligence.Engineering {
     }
     
     public static void AddPerkTooltip(List<TooltipProperty> tooltips, PerkObject perk, float bonusValue) {
-      if (Math.Abs(bonusValue) < 0.05) return;
+      if (bonusValue.IsZero()) return;
       var isRate = perk.IncrementType == SkillEffect.EffectIncrementType.AddFactor;
       var suffix = isRate ? "%" : "";
       var tooltip = new TooltipProperty(perk.Name.ToString(), value: $"{bonusValue:F1}{suffix}", 0);


### PR DESCRIPTION
This pull request adds the perk 'Good Materials', which increases your siege engines max health by 20%.

There are two commits to add the perk 'Good Materials' from engineering tree. The first one only deals with the damage application without any visual tooltips. The second one is supposed to implement the visuals, displaying the increased Max Health Points, which were very tricky to do due to lifecycle limitations when patching. 

**Commit 1**
The first commit have three patches. Since there are two routes to deploy a siege engine, one for player and another for AI, I had to patch them both. However, the player route required two patches to avoid adding references from 'SandBox.ViewModelCollection' into the project.

These two patches check whether the 'deployed siege engine list' has increased. If so, while the reserved siege engines list hasn't decreased, it means a new siege engine has just been deployed, allowing me to grab it by getting the last item of the list. Then it is possible to change its HP, but not the Max HP yet. Here comes the second commit.

**Commit 2** 
After the first commit, it was still necessary to update the Max Health Points from the just deployed siege engine. However, this property was not settable and neither its value stored in its own object. It was pointing to a list of predefined objects (siege engine types) that share their reference across many other siege engines, meaning changing the max hit points of one siege engine, would affect all the other siege engines of same type in the whole map. 

My approach was patching the Max Hit Points property of the siege engine (SiegeEngineConstructionProgress) to make use of a ConditionalWeakTable that would save their Max Hit Points. I chose this approach because it looked functional but I am really open to suggestions. 


