### PR TITLE
add Imperial Fire Perk from Engineering tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
     * Everyday Engineer
     * Builder
     * Armorcraft
+    * Imperial Fire
   * Roguery
     * Party Raiding
     * Eye for Loot

--- a/src/CommunityPatch/FloatHelper.cs
+++ b/src/CommunityPatch/FloatHelper.cs
@@ -5,7 +5,7 @@ namespace CommunityPatch {
   public static class FloatHelper {
 
     private const float Tolerance = 0.0001f;
-      
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsZero(this float value)
       => Math.Abs(value) < Tolerance;
@@ -13,6 +13,9 @@ namespace CommunityPatch {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsDifferentFrom(this float value, float target)
       => Math.Abs(value - target) > Tolerance;
-
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsEqualOrBiggerThan(this float value, float target)
+      => value >= target - Tolerance;
   }
 }

--- a/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/ImperialFirePatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/ImperialFirePatch.cs
@@ -107,7 +107,12 @@ namespace CommunityPatch.Patches.Perks.Intelligence.Engineering {
     private static bool AnyPartyMemberHasThePerkActive(MobileParty party) {
       var perk = ActivePatch._perk;
       var partyMemberValue = new ExplainedNumber(0f);
-      PerkHelper.AddPerkBonusForParty(perk, Hero.MainHero.PartyBelongedTo, ref partyMemberValue);
+      PerkHelper.AddPerkBonusForParty(perk, party, ref partyMemberValue);
+
+      if (party.Army?.Parties != null)
+        foreach (var armyParty in party.Army?.Parties)
+          PerkHelper.AddPerkBonusForParty(perk, armyParty, ref partyMemberValue);
+
       return partyMemberValue.ResultNumber.IsEqualOrBiggerThan(1f);
     }
     

--- a/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/ImperialFirePatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/ImperialFirePatch.cs
@@ -100,14 +100,15 @@ namespace CommunityPatch.Patches.Perks.Intelligence.Engineering {
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Postfix(ref IEnumerable<SiegeEngineType> __result) {
       if (Hero.MainHero == null) return;
-      
+      if (AnyPartyMemberHasThePerkActive(Hero.MainHero.PartyBelongedTo)) return;
+      __result = RemoveFireEngines(__result);
+    }
+    
+    private static bool AnyPartyMemberHasThePerkActive(MobileParty party) {
       var perk = ActivePatch._perk;
       var partyMemberValue = new ExplainedNumber(0f);
       PerkHelper.AddPerkBonusForParty(perk, Hero.MainHero.PartyBelongedTo, ref partyMemberValue);
-      
-      if (partyMemberValue.ResultNumber >= .99) return;
-
-      __result = RemoveFireEngines(__result);
+      return partyMemberValue.ResultNumber.IsEqualOrBiggerThan(1f);
     }
     
     private static IEnumerable<SiegeEngineType> RemoveFireEngines(IEnumerable<SiegeEngineType> engineTypes) 


### PR DESCRIPTION
This pull request will add the perk 'Imperial Fire' which should enable fire siege engines. These fire engines were already enabled by default to every player. So what I had to do is removing those options from players that didn't have the perk active. 

There were two methods to be patched, one for the attacker team, the other for the defender team. 