### PR TITLE
add perk wall breaker and tooltip for ranged wall damage

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
     * Everyday Engineer
     * Builder
     * Armorcraft
+    * Wall Breaker
   * Roguery
     * Party Raiding
     * Eye for Loot

--- a/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/BallisticsPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/BallisticsPatch.cs
@@ -96,7 +96,8 @@ namespace CommunityPatch.Patches.Perks.Intelligence.Engineering {
       
       CalculateBonusDamageAndRates(engineInProgress.SiegeEngine, siegeEventSide, out var bonusRate, out var bonusDamage);
       SiegeTooltipHelper.AddPerkTooltip(__result, ActivePatch._perk, bonusRate);
-      SiegeTooltipHelper.UpdateRangedDamageTooltip(__result, bonusDamage);
+      SiegeTooltipHelper.UpdateRangedDamageToWallsTooltip(__result, bonusDamage);
+      SiegeTooltipHelper.UpdateRangedEngineDamageTooltip(__result, bonusDamage);
     }
     
     // ReSharper disable once InconsistentNaming

--- a/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/WallBreakerPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/WallBreakerPatch.cs
@@ -7,17 +7,19 @@ using TaleWorlds.Core;
 using TaleWorlds.Localization;
 using HarmonyLib;
 using Helpers;
+using TaleWorlds.CampaignSystem.Siege;
 using TaleWorlds.Core.ViewModelCollection;
+using TaleWorlds.Library;
 using static CommunityPatch.HarmonyHelpers;
 
 namespace CommunityPatch.Patches.Perks.Intelligence.Engineering {
 
-  public sealed class HeavierSiegeEnginesPatch : PatchBase<HeavierSiegeEnginesPatch> {
+  public sealed class WallBreakerPatch : PatchBase<WallBreakerPatch> {
     public override bool Applied { get; protected set; }
-    private static readonly MethodInfo TargetMethodInfo = typeof(SiegeEvent).GetMethod("BombardHitEngine", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+    private static readonly MethodInfo TargetMethodInfo = typeof(BesiegerCamp).GetMethod("BombardHitWalls", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
     private static readonly MethodInfo TooltipTargetMethodInfo = SiegeTooltipHelper.TargetMethodInfo;
-    private static readonly MethodInfo PatchMethodInfo = typeof(HeavierSiegeEnginesPatch).GetMethod(nameof(Prefix), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
-    private static readonly MethodInfo TooltipPatchMethodInfo = typeof(HeavierSiegeEnginesPatch).GetMethod(nameof(TooltipPostfix), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+    private static readonly MethodInfo PatchMethodInfo = typeof(WallBreakerPatch).GetMethod(nameof(Prefix), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+    private static readonly MethodInfo TooltipPatchMethodInfo = typeof(WallBreakerPatch).GetMethod(nameof(TooltipPostfix), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
 
     public override IEnumerable<MethodBase> GetMethodsChecked() {
       yield return TargetMethodInfo;
@@ -30,15 +32,15 @@ namespace CommunityPatch.Patches.Perks.Intelligence.Engineering {
     private static readonly byte[][] Hashes = {
       new byte[] {
         // e1.1.0.225190
-        0x97, 0xF2, 0xEB, 0x6F, 0xD0, 0x02, 0x95, 0x39,
-        0x50, 0xEF, 0x10, 0x9B, 0x78, 0x8C, 0xEF, 0xDC,
-        0x42, 0x30, 0x5E, 0x08, 0x02, 0xCE, 0x7E, 0x56,
-        0x53, 0x60, 0x27, 0xA9, 0x84, 0x1C, 0xC3, 0xF2
+        0xE1, 0xB4, 0xCD, 0xF0, 0x16, 0xF2, 0xF1, 0x9F,
+        0x3B, 0x2E, 0x0E, 0x73, 0x72, 0x2F, 0xBF, 0x76,
+        0x60, 0x1E, 0xDA, 0x2E, 0xAF, 0xF7, 0x46, 0xB9,
+        0x5F, 0xE0, 0x48, 0x0B, 0x1E, 0xC5, 0x70, 0x7F
       }
     };
     
     public override void Reset()
-      => _perk = PerkObject.FindFirst(x => x.Name.GetID() == "qXkWSgwA");
+      => _perk = PerkObject.FindFirst(x => x.Name.GetID() == "0wlWgIeL");
 
     public override bool? IsApplicable(Game game)
       // ReSharper disable once CompareOfFloatsByEqualityOperator
@@ -72,7 +74,7 @@ namespace CommunityPatch.Patches.Perks.Intelligence.Engineering {
         _perk.Skill,
         (int) _perk.RequiredSkillValue,
         _perk.AlternativePerk,
-        _perk.PrimaryRole, 20f,
+        _perk.PrimaryRole, 25f,
         _perk.SecondaryRole, _perk.SecondaryBonus,
         _perk.IncrementType
       );
@@ -85,9 +87,20 @@ namespace CommunityPatch.Patches.Perks.Intelligence.Engineering {
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void Prefix(ISiegeEventSide siegeEventSide, SiegeEngineType attackerEngineType, SiegeEvent.SiegeEngineConstructionProgress damagedEngine) {
-      CalculateBonusDamageAndRates(attackerEngineType, siegeEventSide, out _, out var bonusDamageOnly);
-      damagedEngine.SetHitpoints(damagedEngine.Hitpoints - bonusDamageOnly);
+    public static void Prefix(BesiegerCamp __instance, SiegeEngineType attackerEngineType, int wallIndex) {
+      var siegeEventSide = __instance.SiegeEvent?.GetSiegeEventSide(BattleSideEnum.Attacker);
+      if (siegeEventSide == null) return;
+      
+      var besiegedSettlement = __instance.SiegeEvent.BesiegedSettlement;
+      CalculateBonusDamageAndRates(attackerEngineType, siegeEventSide, out _, out var bonusDamage);
+      
+      var wallSections = besiegedSettlement.SettlementWallSectionHitPointsRatioList;
+      if (wallSections[wallIndex] <= 0f) return;
+
+      var targetWallSectionPercentageHp = wallSections[wallIndex];
+      var percentageDamageToWallSection = bonusDamage / besiegedSettlement.MaxHitPointsOfOneWallSection;
+      var targetWallSectionFinalHp = MBMath.ClampFloat(targetWallSectionPercentageHp - percentageDamageToWallSection, 0f, 1f);
+      besiegedSettlement.SetWallSectionHitPointsRatioAtIndex(wallIndex, targetWallSectionFinalHp);
     }
     
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -95,10 +108,9 @@ namespace CommunityPatch.Patches.Perks.Intelligence.Engineering {
       var siegeEventSide = SiegeTooltipHelper.GetConstructionSiegeEventSide(engineInProgress);
       if (siegeEventSide == null) return;
       
-      CalculateBonusDamageAndRates(engineInProgress.SiegeEngine, siegeEventSide, out var bonusRateOnly, out var bonusDamageOnly);
-      SiegeTooltipHelper.AddPerkTooltip(__result, ActivePatch._perk, bonusRateOnly);
-      SiegeTooltipHelper.UpdateRangedDamageToWallsTooltip(__result, 0);
-      SiegeTooltipHelper.UpdateRangedEngineDamageTooltip(__result, bonusDamageOnly);
+      CalculateBonusDamageAndRates(engineInProgress.SiegeEngine, siegeEventSide, out var bonusRate, out var bonusDamage);
+      SiegeTooltipHelper.AddPerkTooltip(__result, ActivePatch._perk, bonusRate);
+      SiegeTooltipHelper.UpdateRangedDamageToWallsTooltip(__result, bonusDamage);
     }
 
     private static void CalculateBonusDamageAndRates(


### PR DESCRIPTION
Add the 'wall breaker' perk that increases damage to walls by 25%. Since from now on the damage to walls differ from the damage to siege engines, I have added a new tooltip property so the player can clearly see how much damage he can apply to each target. 

![image](https://user-images.githubusercontent.com/2680026/79761524-f5c3bc00-82f7-11ea-8651-4a58cb447e9f.png)
