### PR TITLE
Add perks related to raiding

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
     * Good Materials
     * Everyday Engineer
     * Builder
+  * Roguery
+    * Party Raiding
 * Policies
   * Land Grants For Veterans
 * Feats

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
 ### Current Fixes
 
 * Perks
-  * Two Handed
-    * Eviscerate
   * Athletics
     * Extra Arrows
     * Extra Throwing Weapon
@@ -62,6 +60,10 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
     * Builder
   * Roguery
     * Party Raiding
+    * Eye for Loot
+  * Two Handed
+    * Quick Plunder
+    * Eviscerate
 * Policies
   * Land Grants For Veterans
 * Feats

--- a/src/CommunityPatch/Patches/Perks/Cunning/Roguery/EyeForLootPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Roguery/EyeForLootPatch.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using Helpers;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Localization;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Roguery {
+
+  public sealed class EyeForLoot : PatchBase<EyeForLoot> {
+    
+    public override bool Applied { get; protected set; }
+
+    private static readonly MethodInfo TargetMethodInfo = RaidingHelper.TargetMethodInfo;
+    private static readonly MethodInfo PatchMethodInfo = typeof(EyeForLoot).GetMethod(nameof(Prefix), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+    public override IEnumerable<MethodBase> GetMethodsChecked() {
+      yield return TargetMethodInfo;
+    }
+
+    private PerkObject _perk;
+
+    private static readonly byte[][] Hashes = RaidingHelper.Hashes;
+
+    public override void Reset()
+      => _perk = PerkObject.FindFirst(x => x.Name.GetID() == "bRGnkt9B");
+
+    public override bool? IsApplicable(Game game) {
+      if (_perk == null) return false;
+      if (_perk.PrimaryBonus.IsDifferentFrom(.05f)) return false;
+      if (TargetMethodInfo == null) return false;
+      if (RaidingHelper.NextSettlementDamage == null) return false;
+      if (RaidingHelper.IsFinishCalled == null) return false;
+
+      var patchInfo = Harmony.GetPatchInfo(TargetMethodInfo);
+      if (AlreadyPatchedByOthers(patchInfo)) return false;
+
+      var hash = TargetMethodInfo.MakeCilSignatureSha256();
+      return hash.MatchesAnySha256(Hashes);
+    }
+
+    public override void Apply(Game game) {
+      var textObjStrings = TextObject.ConvertToStringList(
+        new List<TextObject> {
+          _perk.Name,
+          _perk.Description
+        }
+      );
+
+      _perk.Initialize(
+        textObjStrings[0],
+        textObjStrings[1],
+        _perk.Skill,
+        (int) _perk.RequiredSkillValue,
+        _perk.AlternativePerk,
+        _perk.PrimaryRole, 5f,
+        _perk.SecondaryRole, _perk.SecondaryBonus,
+        _perk.IncrementType
+      );
+
+      if (Applied) return;
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo, new HarmonyMethod(PatchMethodInfo));
+      Applied = true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Prefix(ref MapEvent __instance) {
+      if (RaidingHelper.IsNotRaidingEvent(__instance)) return;
+      if (RaidingHelper.IsTheRaidHitNotHappeningNow(__instance, out var damageAccumulated)) return;
+      ApplyPerkExtraRewardBonusToRaidHit(__instance, damageAccumulated);
+    }
+
+    private static void ApplyPerkExtraRewardBonusToRaidHit(MapEvent __instance, float hitDamage)
+    {
+      var perk = ActivePatch._perk;
+      var partyMemberHitDamage = new ExplainedNumber(hitDamage);
+
+      foreach (var party in __instance.AttackerSide.Parties.Where(x => x.MobileParty != null))
+        PerkHelper.AddPerkBonusForParty(perk, party.MobileParty, ref partyMemberHitDamage);
+
+      var damageBonus = partyMemberHitDamage.ResultNumber - partyMemberHitDamage.BaseNumber;
+      RaidingHelper.SetHitDamage(__instance, partyMemberHitDamage.ResultNumber);
+      RaidingHelper.IncreaseSettlementHitPoints(__instance, damageBonus);
+    }
+  }
+}

--- a/src/CommunityPatch/Patches/Perks/Cunning/Roguery/RaidingHelper.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Roguery/RaidingHelper.cs
@@ -8,9 +8,10 @@ namespace CommunityPatch.Patches.Perks.Cunning.Roguery {
 
     private const float RaidMinHitDamage = 0.05f;
     private const float PredictionForHitMinDamage = 0.049f;
-    
+
     public static readonly FieldInfo IsFinishCalled = typeof(MapEvent).GetField("_isFinishCalled", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
     public static readonly FieldInfo NextSettlementDamage = typeof(MapEvent).GetField("_nextSettlementDamage", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+    public static readonly PropertyInfo SettlementHitPoints = typeof(Settlement).GetProperty("SettlementHitPoints", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
     public static readonly MethodInfo TargetMethodInfo = typeof(MapEvent).GetMethod("Update", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
     
     public static readonly byte[][] Hashes = {
@@ -44,6 +45,11 @@ namespace CommunityPatch.Patches.Perks.Cunning.Roguery {
     public static void SetHitDamage(MapEvent mapEvent, float hitDamage)
       => NextSettlementDamage.SetValue(mapEvent, Math.Max(hitDamage, RaidingHelper.RaidMinHitDamage));
 
+    public static void IncreaseSettlementHitPoints(MapEvent mapEvent, float extraHitPoints) {
+      var currentHp = (float) SettlementHitPoints.GetValue(mapEvent.MapEventSettlement);
+      SettlementHitPoints.SetValue(mapEvent.MapEventSettlement, currentHp + extraHitPoints);
+    }
+    
     private static bool IsFinished(MapEvent mapEvent) 
       => (bool) IsFinishCalled.GetValue(mapEvent);
     

--- a/src/CommunityPatch/Patches/Perks/Cunning/Roguery/RaidingHelper.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Roguery/RaidingHelper.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Reflection;
+using TaleWorlds.CampaignSystem;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Roguery {
+
+  public static class RaidingHelper {
+
+    private const float RaidMinHitDamage = 0.05f;
+    private const float PredictionForHitMinDamage = 0.049f;
+    
+    public static readonly FieldInfo IsFinishCalled = typeof(MapEvent).GetField("_isFinishCalled", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+    public static readonly FieldInfo NextSettlementDamage = typeof(MapEvent).GetField("_nextSettlementDamage", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+    public static readonly MethodInfo TargetMethodInfo = typeof(MapEvent).GetMethod("Update", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+    
+    public static readonly byte[][] Hashes = {
+      new byte[] {
+        // e1.1.0.225190
+        0xCD, 0xFE, 0x93, 0xE9, 0x4B, 0xC8, 0x7E, 0x94,
+        0xA1, 0x7A, 0xA5, 0x16, 0x39, 0xEF, 0xC1, 0xD6,
+        0x88, 0x09, 0x15, 0x13, 0xF7, 0xCB, 0x1C, 0x6C,
+        0x8D, 0xE1, 0x1A, 0x96, 0x71, 0x39, 0x59, 0xE6
+      }
+    };
+    
+    public static bool IsNotRaidingEvent(MapEvent __instance)
+    {
+      if (IsFinished(__instance)) return true;
+      if (__instance.DiplomaticallyFinished) return true;
+      if (__instance.EventType != MapEvent.BattleTypes.Raid) return true;
+      if (__instance.DefenderSide.TroopCount > 0) return true;
+      return __instance.AttackerSide.LeaderParty?.MobileParty == null;
+    }
+
+    public static bool IsTheRaidHitNotHappeningNow(MapEvent __instance, out float damageAccumulated)
+    {
+      var damage = ((float) Math.Sqrt(__instance.AttackerSide.TroopCount) + 5f) / 500f * (float) CampaignTime.DeltaTime.ToHours;
+      var resistance = __instance.MapEventSettlement.SettlementHitPoints > 0.75f ? 2f : 1f;
+      var realDamage = damage / resistance;
+      damageAccumulated = GetDamageAccumulated(__instance) + realDamage;
+      return damageAccumulated < PredictionForHitMinDamage;
+    }
+
+    public static void SetHitDamage(MapEvent mapEvent, float hitDamage)
+      => NextSettlementDamage.SetValue(mapEvent, Math.Max(hitDamage, RaidingHelper.RaidMinHitDamage));
+
+    private static bool IsFinished(MapEvent mapEvent) 
+      => (bool) IsFinishCalled.GetValue(mapEvent);
+    
+    private static float GetDamageAccumulated(MapEvent mapEvent)
+      => (float)NextSettlementDamage.GetValue(mapEvent);
+
+  }
+
+}

--- a/src/CommunityPatch/Patches/Perks/Cunning/Roguery/RaidingPartyPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Roguery/RaidingPartyPatch.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using Helpers;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Localization;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Roguery {
+
+  public sealed class RaidingPartyPatch : PatchBase<RaidingPartyPatch> {
+    
+    public override bool Applied { get; protected set; }
+
+    private static readonly MethodInfo TargetMethodInfo = RaidingHelper.TargetMethodInfo;
+    private static readonly MethodInfo PatchMethodInfo = typeof(RaidingPartyPatch).GetMethod(nameof(Prefix), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+    public override IEnumerable<MethodBase> GetMethodsChecked() {
+      yield return TargetMethodInfo;
+    }
+
+    private PerkObject _perk;
+
+    private static readonly byte[][] Hashes = RaidingHelper.Hashes;
+
+    public override void Reset()
+      => _perk = PerkObject.FindFirst(x => x.Name.GetID() == "pI0j13oK");
+
+    public override bool? IsApplicable(Game game) {
+      if (_perk == null) return false;
+      if (_perk.PrimaryBonus.IsDifferentFrom(.10f)) return false;
+      if (TargetMethodInfo == null) return false;
+      if (RaidingHelper.NextSettlementDamage == null) return false;
+      if (RaidingHelper.IsFinishCalled == null) return false;
+
+      var patchInfo = Harmony.GetPatchInfo(TargetMethodInfo);
+      if (AlreadyPatchedByOthers(patchInfo)) return false;
+
+      var hash = TargetMethodInfo.MakeCilSignatureSha256();
+      return hash.MatchesAnySha256(Hashes);
+    }
+
+    public override void Apply(Game game) {
+      var textObjStrings = TextObject.ConvertToStringList(
+        new List<TextObject> {
+          _perk.Name,
+          _perk.Description
+        }
+      );
+
+      _perk.Initialize(
+        textObjStrings[0],
+        textObjStrings[1],
+        _perk.Skill,
+        (int) _perk.RequiredSkillValue,
+        _perk.AlternativePerk,
+        _perk.PrimaryRole, 10f,
+        _perk.SecondaryRole, _perk.SecondaryBonus,
+        _perk.IncrementType
+      );
+
+      if (Applied) return;
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo, new HarmonyMethod(PatchMethodInfo));
+      Applied = true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Prefix(ref MapEvent __instance) {
+      if (RaidingHelper.IsNotRaidingEvent(__instance)) return;
+      if (RaidingHelper.IsTheRaidHitNotHappeningNow(__instance, out var damageAccumulated)) return;
+      ApplyPerkBonusToRaidHit(__instance, damageAccumulated);
+    }
+
+    private static void ApplyPerkBonusToRaidHit(MapEvent __instance, float hitDamage)
+    {
+      var perk = ActivePatch._perk;
+      var partyMemberHitDamage = new ExplainedNumber(hitDamage);
+
+      foreach (var party in __instance.AttackerSide.Parties.Where(x => x.MobileParty != null))
+        PerkHelper.AddPerkBonusForParty(perk, party.MobileParty, ref partyMemberHitDamage);
+
+      RaidingHelper.SetHitDamage(__instance, partyMemberHitDamage.ResultNumber);
+    }
+  }
+}

--- a/src/CommunityPatch/Patches/Perks/Vigor/TwoHanded/QuickPlunderPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Vigor/TwoHanded/QuickPlunderPatch.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using Helpers;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Localization;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Roguery {
+
+  public sealed class QuickPlunderPatch : PatchBase<QuickPlunderPatch> {
+    
+    public override bool Applied { get; protected set; }
+
+    private static readonly MethodInfo TargetMethodInfo = RaidingHelper.TargetMethodInfo;
+    private static readonly MethodInfo PatchMethodInfo = typeof(QuickPlunderPatch).GetMethod(nameof(Prefix), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+    public override IEnumerable<MethodBase> GetMethodsChecked() {
+      yield return TargetMethodInfo;
+    }
+
+    private PerkObject _perk;
+
+    private static readonly byte[][] Hashes = RaidingHelper.Hashes;
+
+    public override void Reset()
+      => _perk = PerkObject.FindFirst(x => x.Name.GetID() == "9hhpbcOI");
+
+    public override bool? IsApplicable(Game game) {
+      if (_perk == null) return false;
+      if (_perk.PrimaryBonus.IsDifferentFrom(.05f)) return false;
+      if (TargetMethodInfo == null) return false;
+      if (RaidingHelper.NextSettlementDamage == null) return false;
+      if (RaidingHelper.IsFinishCalled == null) return false;
+
+      var patchInfo = Harmony.GetPatchInfo(TargetMethodInfo);
+      if (AlreadyPatchedByOthers(patchInfo)) return false;
+
+      var hash = TargetMethodInfo.MakeCilSignatureSha256();
+      return hash.MatchesAnySha256(Hashes);
+    }
+
+    public override void Apply(Game game) {
+      var textObjStrings = TextObject.ConvertToStringList(
+        new List<TextObject> {
+          _perk.Name,
+          _perk.Description
+        }
+      );
+
+      _perk.Initialize(
+        textObjStrings[0],
+        textObjStrings[1],
+        _perk.Skill,
+        (int) _perk.RequiredSkillValue,
+        _perk.AlternativePerk,
+        _perk.PrimaryRole, 5f,
+        _perk.SecondaryRole, _perk.SecondaryBonus,
+        _perk.IncrementType
+      );
+
+      if (Applied) return;
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo, new HarmonyMethod(PatchMethodInfo));
+      Applied = true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Prefix(ref MapEvent __instance) {
+      if (RaidingHelper.IsNotRaidingEvent(__instance)) return;
+      if (RaidingHelper.IsTheRaidHitNotHappeningNow(__instance, out var damageAccumulated)) return;
+      ApplyPerkBonusToRaidHit(__instance, damageAccumulated);
+    }
+
+    private static void ApplyPerkBonusToRaidHit(MapEvent __instance, float hitDamage)
+    {
+      var perk = ActivePatch._perk;
+      var partyMemberHitDamage = new ExplainedNumber(hitDamage);
+
+      foreach (var party in __instance.AttackerSide.Parties.Where(x => x.MobileParty != null))
+        PerkHelper.AddPerkBonusForParty(perk, party.MobileParty, ref partyMemberHitDamage);
+
+      RaidingHelper.SetHitDamage(__instance, partyMemberHitDamage.ResultNumber);
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds three perks that are all related and very similar in the implementation. Due to the very similarity in code, I thought it made sense to PR it all together. These are the affected perks related to raiding: 
- Quick plunderer (two handed tree): +5% raiding speed
- Raiding party (roguery): +10% raiding speed
- Eye for loot (roguery): +5% raiding loot

**Raiding System**
It is worth explaining how the raiding system works. When a character is raiding a settlement, it shows up a raiding bar that is just the settlement HP. Everytime the raiding damage is applied, loot are given to the player. However, it is worthy noting that the damage is only applied in amounts equal or bigger than 5% of the settlement hp (settlement HP is a factor from 0 to 1). So any lesser damage is accumulated in a variable until it reaches the minimum 5%. But how and when is the damage?

Well, the damage is based on the number of troops raiding the village, but I won't get into details about it, unless needed. What is worthy mentioning is that the damage is applied by many ticks that happens in an hour (game time). Every tick will try to apply extra damage, but it is so small it gets accumulated until it reaches the beforementioned minimum.

So how did I implement the patches to increase raiding speed and extra loot? 

**The patches** 
Since the raiding original implementation was a bit of a mess, almost without any method calls, I thought I would have to either reimplement it from scratch, or make a 'Prefix patch' that would predict when the minimum %5 blow would happen, so I could inject an extra damage according to the perks bonuses. I went for the latter option. 

The patches try to predict, and they very efficient on it, when the minimum %5 hit is going to happen. So, in order to increase the raiding speed, it was just a matter of increasing the damage, which would be applied, by the perks bonuses (this is how it works for quick plunderer and party raiding).

The implementation for the extra loot is not very different. It takes in consideration that the bigger the damage, the bigger the reward (loot). So It will work the same way as the other perks, increasing damage but with an exception: It will also increase the settlement hitpoints by the same amount. Therefore, internally, what happens is that more damage is applied, giving more rewards, but the final settlement HP remains the same as expected because it was previously increased. 

I have done a good amount of testing for all the three perks, and they've been working fine. The prediction hasn't missed yet, after several calibrations. The three patches make use of a RaidingHelper, to reuse code.
