### PR TITLE
add morale gain on raiding and the perk for the thrill from roguery

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
   * Roguery
     * Party Raiding
     * Eye for Loot
+    * For the Thrill
   * Two Handed
     * Quick Plunder
     * Eviscerate

--- a/src/CommunityPatch/Patches/Perks/Cunning/Roguery/ForTheThrillPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Roguery/ForTheThrillPatch.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using Helpers;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Localization;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Roguery {
+  public class ForTheThrillPatch : PatchBase<ForTheThrillPatch> {
+    public override bool Applied { get; protected set; }
+    
+    private static readonly MethodInfo TargetMethodInfo = typeof(MapEvent).GetMethod("ApplyRaidResult", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+    private static readonly MethodInfo PatchMethodInfoPrefix = typeof(ForTheThrillPatch).GetMethod(nameof(Prefix), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+    public override IEnumerable<MethodBase> GetMethodsChecked() {
+      yield return TargetMethodInfo;
+    }
+
+    private PerkObject _perk;
+
+    private static readonly byte[][] Hashes = {
+      new byte[] {
+        // e1.1.0.225190
+        0x67, 0x3C, 0x63, 0x7B, 0xD0, 0x08, 0x5F, 0x69,
+        0x3F, 0x88, 0xE0, 0xC0, 0x35, 0xE9, 0x97, 0x67,
+        0xBF, 0x14, 0xBB, 0xF6, 0xCA, 0x11, 0x72, 0x13,
+        0x23, 0xE2, 0x25, 0x97, 0x10, 0x2C, 0xA5, 0xAA
+      }
+    };
+    
+    public override void Reset()
+      => _perk = PerkObject.FindFirst(x => x.Name.GetID() == "WACam22Q");
+
+    public override bool? IsApplicable(Game game) {
+      if (_perk == null) return false;
+
+      var patchInfo = Harmony.GetPatchInfo(TargetMethodInfo);
+      if (AlreadyPatchedByOthers(patchInfo)) return false;
+
+      var hash = TargetMethodInfo.MakeCilSignatureSha256();
+      return hash.MatchesAnySha256(Hashes);
+    }
+
+    public override void Apply(Game game) {
+      var textObjStrings = TextObject.ConvertToStringList(
+        new List<TextObject> {
+          _perk.Name,
+          _perk.Description
+        }
+      );
+      
+      _perk.Initialize(
+        textObjStrings[0],
+        textObjStrings[1],
+        _perk.Skill,
+        (int) _perk.RequiredSkillValue,
+        _perk.AlternativePerk,
+        _perk.PrimaryRole, 10f,
+        _perk.SecondaryRole, _perk.SecondaryBonus,
+        _perk.IncrementType
+      );
+      
+      if (Applied) return;
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo, new HarmonyMethod(PatchMethodInfoPrefix));
+      Applied = true;
+    }
+
+    // ReSharper disable once InconsistentNaming
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Prefix(ref MapEvent __instance) {
+      var attackers = __instance.AttackerSide.Parties.Where(x => x.MobileParty != null).ToArray();
+      var moraleGain = CalculateMoralGain(attackers);
+      
+      foreach (var attacker in attackers)
+        attacker.MobileParty.RecentEventsMorale += moraleGain;
+    }
+
+    private static float CalculateMoralGain(IEnumerable<PartyBase> attackers) {
+      var moraleGain = new ExplainedNumber(4f);
+      var perk = ActivePatch._perk;
+      
+      foreach (var attacker in attackers)
+        PerkHelper.AddPerkBonusForParty(perk, attacker.MobileParty, ref moraleGain);
+      
+      return moraleGain.ResultNumber;
+    }
+  }
+
+}


### PR DESCRIPTION
The perk for thrill is supposed to increase morale gain on raids by 10%. However there is no morale gain during or after a raid. So, to make this perk any useful without deviating from its description, I have implemented a small morale reward from raids. When a party/parties finishes a raid, they all receive 4 morale points in 'Recent Events'. 

 

