### PR TITLE
add perk Briber from roguery

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
     * Eye for Loot
     * For the Thrill
     * Slip into Shadows
+    * Briber
   * Two Handed
     * Quick Plunder
     * Eviscerate

--- a/src/CommunityPatch/Patches/Perks/Cunning/Roguery/BriberPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Roguery/BriberPatch.cs
@@ -1,0 +1,177 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using Helpers;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.SandBox.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.SandBox.CampaignBehaviors.VillageBehaviors;
+using TaleWorlds.Core;
+using TaleWorlds.Localization;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Roguery {
+
+  public sealed class BriberPatch : PatchBase<BriberPatch> {
+    
+    public override bool Applied { get; protected set; }
+
+    private static readonly MethodInfo VillagerBribeTargetMethodInfo = typeof(VillagerCampaignBehavior).GetMethod("IsBribeFeasible", BindingFlags.NonPublic | BindingFlags.DeclaredOnly | BindingFlags.Instance);
+    private static readonly MethodInfo VillagerSurrenderTargetMethodInfo = typeof(VillagerCampaignBehavior).GetMethod("IsSurrenderFeasible", BindingFlags.NonPublic | BindingFlags.DeclaredOnly | BindingFlags.Instance);
+    private static readonly MethodInfo CaravansBribeTargetMethodInfo = typeof(CaravansCampaignBehavior).GetMethod("IsBribeFeasible", BindingFlags.NonPublic | BindingFlags.DeclaredOnly | BindingFlags.Instance);
+    private static readonly MethodInfo CaravansSurrenderTargetMethodInfo = typeof(CaravansCampaignBehavior).GetMethod("IsSurrenderFeasible", BindingFlags.NonPublic | BindingFlags.DeclaredOnly | BindingFlags.Instance);
+
+    private static readonly MethodInfo VillagerBribePatchMethodInfo = typeof(BriberPatch).GetMethod(nameof(PrefixVillageBribe), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+    private static readonly MethodInfo VillagerSurrenderPatchMethodInfo = typeof(BriberPatch).GetMethod(nameof(PrefixVillageSurrender), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+    private static readonly MethodInfo CaravansBribePatchMethodInfo = typeof(BriberPatch).GetMethod(nameof(PrefixCaravansBribe), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+    private static readonly MethodInfo CaravansSurrenderPatchMethodInfo = typeof(BriberPatch).GetMethod(nameof(PrefixCaravansSurrender), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+    public override IEnumerable<MethodBase> GetMethodsChecked() {
+      yield return VillagerBribeTargetMethodInfo;
+      yield return VillagerSurrenderTargetMethodInfo;
+      yield return CaravansBribeTargetMethodInfo;
+      yield return CaravansSurrenderTargetMethodInfo;
+    }
+
+    private PerkObject _perk;
+
+    private static readonly byte[][] VillagerBribeHashes = {
+      new byte[] {
+        // e1.1.0.225190
+        0x34, 0xFC, 0xFA, 0xC6, 0x4B, 0x12, 0xCB, 0x84,
+        0x1C, 0xA0, 0x96, 0xF4, 0xEC, 0x2B, 0xD4, 0x21,
+        0x0D, 0xF3, 0x30, 0x4B, 0x96, 0x62, 0x92, 0x32,
+        0xBF, 0x96, 0xDF, 0x03, 0xA1, 0xEA, 0xAE, 0x19
+      }
+    };
+    
+    private static readonly byte[][] VillagerSurrenderHashes = {
+      new byte[] {
+        // e1.1.0.225190
+        0x62, 0x63, 0xC2, 0x33, 0xD9, 0xEB, 0x09, 0xBA,
+        0xE5, 0xEF, 0xCF, 0x7A, 0xBC, 0xFF, 0x49, 0x45,
+        0x16, 0xF4, 0x67, 0x5A, 0x01, 0x68, 0xFA, 0xDC,
+        0xEC, 0xA3, 0x9B, 0xB0, 0x3B, 0x67, 0x39, 0x5A
+      }
+    };
+    
+    private static readonly byte[][] CaravansBribeHashes = {
+      new byte[] {
+        // e1.1.0.225190
+        0x09, 0x11, 0xA8, 0x72, 0x94, 0xC0, 0x05, 0x88,
+        0x61, 0xD6, 0x44, 0x6A, 0xEF, 0x0B, 0xC8, 0xD4,
+        0x34, 0xAE, 0xA4, 0xBE, 0xAC, 0x70, 0x40, 0x00,
+        0x3C, 0xB5, 0x24, 0xCB, 0x11, 0x97, 0x44, 0x54
+      }
+    };
+    
+    private static readonly byte[][] CaravansSurrenderHashes = {
+      new byte[] {
+        // e1.1.0.225190
+        0x07, 0xAC, 0x8C, 0x34, 0x03, 0x89, 0x95, 0xDD,
+        0x73, 0xAE, 0xC9, 0xBB, 0x9B, 0xC6, 0x5F, 0xB3,
+        0xD9, 0x2C, 0x4B, 0x75, 0xDC, 0x5A, 0xFF, 0xA3,
+        0x05, 0xEB, 0x09, 0x64, 0x54, 0xC5, 0x27, 0xC7
+      }
+    };
+
+    public override void Reset()
+      => _perk = PerkObject.FindFirst(x => x.Name.GetID() == "5Trq1mQL");
+
+    public override bool? IsApplicable(Game game) {
+      if (_perk == null) return false;
+      
+      var villagerBribePatchInfo = Harmony.GetPatchInfo(VillagerBribeTargetMethodInfo);
+      if (AlreadyPatchedByOthers(villagerBribePatchInfo)) return false;
+      
+      var villagerSurrenderPatchInfo = Harmony.GetPatchInfo(VillagerSurrenderTargetMethodInfo);
+      if (AlreadyPatchedByOthers(villagerSurrenderPatchInfo)) return false;
+      
+      var caravansBribePatchInfo = Harmony.GetPatchInfo(CaravansBribeTargetMethodInfo);
+      if (AlreadyPatchedByOthers(caravansBribePatchInfo)) return false;
+      
+      var caravansSurrenderPatchInfo = Harmony.GetPatchInfo(CaravansSurrenderTargetMethodInfo);
+      if (AlreadyPatchedByOthers(caravansSurrenderPatchInfo)) return false;
+      
+      var villagerBribeHash = VillagerBribeTargetMethodInfo.MakeCilSignatureSha256();
+      var villagerSurrenderHash = VillagerSurrenderTargetMethodInfo.MakeCilSignatureSha256();
+      var caravansBribeHash = CaravansBribeTargetMethodInfo.MakeCilSignatureSha256();
+      var caravansSurrenderHash = CaravansSurrenderTargetMethodInfo.MakeCilSignatureSha256();
+      return villagerBribeHash.MatchesAnySha256(VillagerBribeHashes) && 
+        villagerSurrenderHash.MatchesAnySha256(VillagerSurrenderHashes) &&
+        caravansBribeHash.MatchesAnySha256(CaravansBribeHashes) && 
+        caravansSurrenderHash.MatchesAnySha256(CaravansSurrenderHashes);
+    }
+
+    public override void Apply(Game game) {
+      var textObjStrings = TextObject.ConvertToStringList(
+        new List<TextObject> {
+          _perk.Name,
+          _perk.Description
+        }
+      );
+
+      _perk.Initialize(
+        textObjStrings[0],
+        textObjStrings[1],
+        _perk.Skill,
+        (int) _perk.RequiredSkillValue,
+        _perk.AlternativePerk,
+        _perk.PrimaryRole, 15f,
+        _perk.SecondaryRole, _perk.SecondaryBonus,
+        _perk.IncrementType
+      );
+
+      if (Applied) return;
+      CommunityPatchSubModule.Harmony.Patch(VillagerBribeTargetMethodInfo, new HarmonyMethod(VillagerBribePatchMethodInfo));
+      CommunityPatchSubModule.Harmony.Patch(VillagerSurrenderTargetMethodInfo, new HarmonyMethod(VillagerSurrenderPatchMethodInfo));
+      CommunityPatchSubModule.Harmony.Patch(CaravansBribeTargetMethodInfo, new HarmonyMethod(CaravansBribePatchMethodInfo));
+      CommunityPatchSubModule.Harmony.Patch(CaravansSurrenderTargetMethodInfo, new HarmonyMethod(CaravansSurrenderPatchMethodInfo));
+      Applied = true;
+    }
+
+    // ReSharper disable once RedundantAssignment
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static bool PrefixVillageBribe(ref bool __result) {
+      __result = Bribe(3, .05f, .4f);
+      return false;
+    }
+    
+    // ReSharper disable once RedundantAssignment
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static bool PrefixVillageSurrender(ref bool __result) {
+      __result = Bribe(4, .05f, .1f);
+      return false;
+    }
+    
+    // ReSharper disable once RedundantAssignment
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static bool PrefixCaravansBribe(ref bool __result) {
+      __result = Bribe(4, .1f, .6f);
+      return false;
+    }
+    
+    // ReSharper disable once RedundantAssignment
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static bool PrefixCaravansSurrender(ref bool __result) {
+      __result = Bribe(7, .1f, .1f);
+      return false;
+    }
+    
+    private static bool Bribe(int randomIndex, float phaseOneAcceptablePowerRatio, float phaseTwoAcceptablePowerRatio) {
+      var isLogicalSurrender = PartyBaseHelper.DoesSurrenderIsLogicalForParty(MobileParty.ConversationParty, MobileParty.MainParty, phaseOneAcceptablePowerRatio);
+      var bribeSuccessChances = isLogicalSurrender ? 67 : 33;
+      var perk = ActivePatch._perk;
+
+      if (MobileParty.MainParty.LeaderHero?.GetPerkValue(perk) == true)
+        bribeSuccessChances += (int)perk.PrimaryBonus;
+
+      if (MobileParty.ConversationParty.Party.Random.GetValue(randomIndex) > bribeSuccessChances) return false;
+      
+      return PartyBaseHelper.DoesSurrenderIsLogicalForParty(
+        MobileParty.ConversationParty, 
+        MobileParty.MainParty, 
+        phaseTwoAcceptablePowerRatio);
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds the perk Briber from roguery. It increases the chances of bribery dialogues to appear by 15%. When you try to force a villager or caravan into giving you their money, it opens bribery related dialogues in case of success. The chances are defined like this: When your party is stronger than the villager/caravan in a certain proportion, you get 66% chance of success; otherwise you receive only 33%. So the perk increases this chance, opening bribery dialogues on success.  

