### PR TITLE
add perk slave trader from roguery

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
     * Eye for Loot
     * For the Thrill
     * Slip into Shadows
-    * Slave Trader
     * Merry men
+    * Slave Trader
   * Two Handed
     * Quick Plunder
     * Eviscerate


### PR DESCRIPTION
Adds the roguery perk 'Slave trader' which increases your profits from ransoming by 20%. It seems every ransom related action calls the method CharacterObject.PrisonerRansomValue to determine the value of the prisioner; even when bartering them.