### PR TITLE
add the roguery perk Merry men

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
     * Eye for Loot
     * For the Thrill
     * Slip into Shadows
+    * Merry men
   * Two Handed
     * Quick Plunder
     * Eviscerate

--- a/src/CommunityPatch/Patches/Perks/Cunning/Roguery/MerryMenPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Roguery/MerryMenPatch.cs
@@ -64,6 +64,7 @@ namespace CommunityPatch.Patches.Perks.Cunning.Roguery {
       intimidated = PartyBaseHelper.DoesSurrenderIsLogicalForParty(
         MobileParty.ConversationParty, 
         MobileParty.MainParty, 
+        // requires that the bandits be merely less than 100% of our strength to surrender.
         1f);
 
       return false;

--- a/src/CommunityPatch/Patches/Perks/Cunning/Roguery/MerryMenPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Roguery/MerryMenPatch.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using Helpers;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.SandBox.CampaignBehaviors;
+using TaleWorlds.Core;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Roguery {
+
+  public sealed class MerryMenPatch : PatchBase<MerryMenPatch> {
+    
+    public override bool Applied { get; protected set; }
+
+    private static readonly MethodInfo BanditsJoinTargetMethodInfo = typeof(BanditsCampaignBehavior).GetMethod("conversation_bandits_will_join_player_on_condition", BindingFlags.NonPublic | BindingFlags.DeclaredOnly | BindingFlags.Instance);
+    private static readonly MethodInfo BanditsJoinPatchMethodInfo = typeof(MerryMenPatch).GetMethod(nameof(PrefixBanditsJoin), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+    public override IEnumerable<MethodBase> GetMethodsChecked() {
+      yield return BanditsJoinTargetMethodInfo;
+    }
+
+    private PerkObject _perk;
+
+    private static readonly byte[][] BanditsJoinHashes = {
+      new byte[] {
+        // e1.1.0.225190
+        0xB1, 0x5A, 0x5C, 0xF7, 0x1A, 0x50, 0x55, 0xFF,
+        0x13, 0x70, 0xD2, 0xA5, 0x69, 0x27, 0x60, 0x8F,
+        0x4A, 0xF9, 0x8E, 0x46, 0x8B, 0xE1, 0x96, 0xD9,
+        0x1E, 0x4F, 0x7B, 0x2B, 0x43, 0x74, 0x8B, 0x4C
+      }
+    };
+
+    public override void Reset()
+      => _perk = PerkObject.All.ToList().LastOrDefault(x => x.Name.GetID() == "ssljPTUr");
+
+    public override bool? IsApplicable(Game game) {
+      if (_perk == null) return false;
+      
+      var banditsJoinPatchInfo = Harmony.GetPatchInfo(BanditsJoinTargetMethodInfo);
+      if (AlreadyPatchedByOthers(banditsJoinPatchInfo)) return false;
+      
+      var banditsJoinHash = BanditsJoinTargetMethodInfo.MakeCilSignatureSha256();
+      return banditsJoinHash.MatchesAnySha256(BanditsJoinHashes);
+    }
+
+    public override void Apply(Game game) {
+      if (Applied) return;
+      CommunityPatchSubModule.Harmony.Patch(BanditsJoinTargetMethodInfo, new HarmonyMethod(BanditsJoinPatchMethodInfo));
+      Applied = true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static bool PrefixBanditsJoin(ref bool __result)
+      => ApplyPerkToMakeRecruitable(ref __result);
+
+    private static bool ApplyPerkToMakeRecruitable(ref bool intimidated) {
+      var perk = ActivePatch._perk;
+      if (MobileParty.MainParty.LeaderHero?.GetPerkValue(perk) != true) return true;
+      
+      intimidated = PartyBaseHelper.DoesSurrenderIsLogicalForParty(
+        MobileParty.ConversationParty, 
+        MobileParty.MainParty, 
+        1f);
+
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the roguery perk  Merry men' that should allow you to recruit bandits. Recruiting bandits was already possible but would required a massive army to intimidate them. Not just that, it would require also luck. By having the perk, the recruitment should require just a minimum number of soldiers and nothing else. 

An important note. The perk ID was not unique, it was the same as the bow perk 'Merry Men'.