### PR TITLE
add perk tactical superiority from tactics

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
   * Two Handed
     * Quick Plunder
     * Eviscerate
+  * Tactics
+    * Tactical Superiority
 * Policies
   * Land Grants For Veterans
 * Feats

--- a/src/CommunityPatch/Patches/Perks/Cunning/Tactics/TacticalSuperiorityPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Tactics/TacticalSuperiorityPatch.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.SandBox.GameComponents.Map;
+using TaleWorlds.Core;
+using TaleWorlds.Localization;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Tactics {
+
+  public class TacticalSuperiorityPatch : PatchBase<TacticalSuperiorityPatch> {
+    
+    public override bool Applied { get; protected set; }
+
+    private static readonly MethodInfo TargetMethodInfo = typeof(DefaultCombatSimulationModel).GetMethod(nameof(DefaultCombatSimulationModel.SimulateHit), BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+    private static readonly MethodInfo PatchMethodInfo = typeof(TacticalSuperiorityPatch).GetMethod(nameof(Postfix), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+    public override IEnumerable<MethodBase> GetMethodsChecked() {
+      yield return TargetMethodInfo;
+    }
+
+    private PerkObject _perk;
+
+    private static readonly byte[][] Hashes = {
+      new byte[] {
+        // e1.1.0.225190
+        0x01, 0x52, 0x68, 0x11, 0x93, 0xB2, 0xA1, 0x81,
+        0x78, 0x07, 0xBE, 0x35, 0xBB, 0x79, 0x66, 0x53,
+        0x0B, 0x62, 0x52, 0xD2, 0x3F, 0xAA, 0xB5, 0xC0,
+        0x69, 0xBC, 0x13, 0xFF, 0x40, 0xD4, 0x49, 0x4C
+      }
+    };
+
+    public override void Reset()
+      => _perk = PerkObject.FindFirst(x => x.Name.GetID() == "gBKb8DoH");
+
+    public override bool? IsApplicable(Game game) {
+      if (_perk == null) return false;
+
+      var patchInfo = Harmony.GetPatchInfo(TargetMethodInfo);
+      if (AlreadyPatchedByOthers(patchInfo)) return false;
+
+      var hash = TargetMethodInfo.MakeCilSignatureSha256();
+      return hash.MatchesAnySha256(Hashes);
+    }
+
+    public override void Apply(Game game) {
+      var textObjStrings = TextObject.ConvertToStringList(
+        new List<TextObject> {
+          _perk.Name,
+          _perk.Description
+        }
+      );
+
+      _perk.Initialize(
+        textObjStrings[0],
+        textObjStrings[1],
+        _perk.Skill,
+        (int) _perk.RequiredSkillValue,
+        _perk.AlternativePerk,
+        _perk.PrimaryRole, .05f,
+        _perk.SecondaryRole, _perk.SecondaryBonus,
+        _perk.IncrementType
+      );
+
+      if (Applied) return;
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo, postfix: new HarmonyMethod(PatchMethodInfo));
+      Applied = true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Postfix(ref int __result, PartyBase strikerParty) {
+      var perk = ActivePatch._perk;
+      if (strikerParty.LeaderHero?.GetPerkValue(perk) != true) return;
+
+      __result += (int) (__result * perk.PrimaryBonus);
+    }
+  }
+}


### PR DESCRIPTION
This adds the perk tactical superiority which increases soldiers damage by 5% during simulations. There is a method that calculates the soldiers damage. I just had to postfix it and increase the output by 5% when striker party leader had the perk active.