### PR TITLE
EarlyStoryVisibleTimeoutPatch: check for game type being story mode

### DIFF
--- a/src/CommunityPatch/Patches/EarlyStoryVisibleTimeoutPatch.cs
+++ b/src/CommunityPatch/Patches/EarlyStoryVisibleTimeoutPatch.cs
@@ -18,6 +18,7 @@ namespace CommunityPatch.Patches {
 
     private static readonly byte[] IsRemainingTimeHiddenGetterBodyIl = {
       // e1.1.2.226306
+      // i.e. IL for "return true"
       (byte) OpCodes.Ldc_I4_1.Value, // 0x17
       (byte) OpCodes.Ret.Value, // 0x2a
     };
@@ -69,10 +70,11 @@ namespace CommunityPatch.Patches {
       if (FirstPhaseTimeLimitInYearsField == null)
         return false;
 
-      if (GameNetwork.IsMultiplayer)
+      Type CampaignStoryModeType = Type.GetType("StoryMode.CampaignStoryMode, StoryMode, Version=1.0.0.0, Culture=neutral", false);
+      if (CampaignStoryModeType == null)
         return false;
 
-      if (Type.GetType("StoryMode.CampaignStoryMode, StoryMode, Version=1.0.0.0, Culture=neutral", false) == null)
+      if (!game.GameType.GetType().IsEquivalentTo(CampaignStoryModeType))
         return false;
 
       if (FirstPhaseQuestRemainingTimeHiddenGetters.Count == 0)


### PR DESCRIPTION
Instead of the patch stopping if we are in multiplayer, instead stop if we are in any game mode other than CampaignStoryMode.

I'm not absolutely certain, but basically because all the base game code checks in the this way (for CampaignStoryMode) before accessing story mode vars. Also hypothetically TW might add a new game mode in the future which is not multiplayer but is also not CampaignStoryMode and in that case the patch would incorrectly apply itself.