### PR TITLE
add 'one step ahead perk' from tactics

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
     * Good Materials
     * Everyday Engineer
     * Builder
-  * Roguery
     * Scavenger
     * Armorcraft
     * Wall Breaker
@@ -81,6 +80,7 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
   * Tactics
     * Companion Cavalry
     * Tactical Superiority
+    * One Step Ahead
 * Policies
   * Land Grants For Veterans
 * Feats

--- a/src/CommunityPatch/Patches/Perks/Cunning/Tactics/OneStepAheadPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Tactics/OneStepAheadPatch.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using static System.Reflection.BindingFlags;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Tactics {
+
+  public class OneStepAheadPatch : PatchBase<OneStepAheadPatch> {
+
+    public override bool Applied { get; protected set; }
+
+    private static readonly Type MapNavigationHandler = Type.GetType("SandBox.View.Map.MapNavigationHandler, SandBox.View, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
+    private static readonly MethodInfo TargetMethodInfo = MapNavigationHandler?.GetMethod("get_PartyEnabled", Public | Instance | DeclaredOnly);
+    private static readonly MethodInfo PatchMethodInfo = typeof(OneStepAheadPatch).GetMethod(nameof(Postfix), Public | NonPublic | Static | DeclaredOnly);
+
+    public override IEnumerable<MethodBase> GetMethodsChecked() {
+      yield return TargetMethodInfo;
+    }
+
+    private PerkObject _perk;
+
+    private static readonly byte[][] Hashes = {
+      new byte[] {
+        // e1.2.1.226961
+        0x77, 0x65, 0x41, 0xC8, 0x63, 0xEC, 0xA9, 0x04,
+        0x8C, 0x06, 0xDB, 0xEF, 0x05, 0x97, 0xE0, 0x66,
+        0x61, 0x20, 0x7D, 0xBC, 0x1C, 0xA8, 0xB5, 0x87,
+        0x88, 0x5F, 0xE5, 0x30, 0xC4, 0xF4, 0xB6, 0x8C
+      }
+    };
+
+    public override void Reset()
+      => _perk = PerkObject.FindFirst(x => x.Name.GetID() == "V6mvBGDV");
+
+    public override bool? IsApplicable(Game game) {
+      if (_perk == null) return false;
+      if (TargetMethodInfo == null) return false;
+
+      var patchInfo = Harmony.GetPatchInfo(TargetMethodInfo);
+      if (AlreadyPatchedByOthers(patchInfo)) return false;
+
+      var hash = TargetMethodInfo.MakeCilSignatureSha256();
+      return hash.MatchesAnySha256(Hashes);
+    }
+
+    public override void Apply(Game game) {
+      if (Applied) return;
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo, postfix: new HarmonyMethod(PatchMethodInfo));
+      Applied = true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Postfix(ref bool __result, ref object __instance) {
+      if (__result) return;
+      if (IsPartyActive(__instance)) return;
+      if (Hero.MainHero.HeroState == Hero.CharacterStates.Prisoner) return;
+      if (MobileParty.MainParty.MapEvent == null) return;
+
+      var perk = ActivePatch._perk;
+      __result = Hero.MainHero.GetPerkValue(perk);
+    }
+
+    private static bool IsPartyActive(object handler) {
+      var property = MapNavigationHandler.GetProperty("PartyActive", Public | Instance | DeclaredOnly);
+      return property != null && (bool) property.GetValue(handler);
+    }
+  }
+
+}


### PR DESCRIPTION
This PR adds the perk 'one step ahead' from tactics tree that says 'Allows you to place your troops before all battles'. 

What I have implemented is the enabling of the 'Party [P]' menu when an Battle event is about to happen and perk is active. So you can organize your party formation before battle. This likely might not be the real expectation for the skill, but I thought it could be a good temporary replacement while TW don't implement the perk. 