### PR TITLE
Fix story patch UI oddities, add missing first phase quests, misc fixes

### DIFF
--- a/src/CommunityPatch/Patches/EarlyStoryVisibleTimeoutPatch.cs
+++ b/src/CommunityPatch/Patches/EarlyStoryVisibleTimeoutPatch.cs
@@ -24,16 +24,21 @@ namespace CommunityPatch.Patches {
       (byte) OpCodes.Ret.Value, // 0x2a
     };
 
-    private static readonly Type FirstPhaseType = Type.GetType("StoryMode.StoryModePhases.FirstPhase, StoryMode, Version=1.0.0.0, Culture=neutral");
+    private const string StoryModeAsmSpecifierSuffix = ", StoryMode, Version=1.0.0.0, Culture=neutral";
+
+    private static readonly Type FirstPhaseType = Type.GetType("StoryMode.StoryModePhases.FirstPhase" + StoryModeAsmSpecifierSuffix);
 
     private static readonly List<MethodInfo> FirstPhaseQuestRemainingTimeHiddenGetters =
       FirstPhaseType.Assembly.GetTypes()
         .Where(type => type.Namespace == "StoryMode.Behaviors.Quests.FirstPhase" && type.IsSubclassOf(typeof(QuestBase)))
-        .Select(type => AccessTools.PropertyGetter(type, "IsRemainingTimeHidden")).ToList();
+        .Append(Type.GetType("StoryMode.Behaviors.Quests.MeetWithArzagosQuestBehavior+MeetWithArzagosQuest" + StoryModeAsmSpecifierSuffix))
+        .Append(Type.GetType("StoryMode.Behaviors.Quests.SupportKingdomQuestBehavior+SupportKingdomQuest" + StoryModeAsmSpecifierSuffix))
+        .Select(type => AccessTools.PropertyGetter(type, "IsRemainingTimeHidden"))
+        .ToList();
 
     private static readonly MethodInfo RemainingTimeHiddenGetterPostfixHandle = AccessTools.Method(typeof(EarlyStoryVisibleTimeoutPatch), nameof(RemainingTimeHiddenGetterPostfix));
 
-    private static readonly Type FirstPhaseCampaignBehaviorType = Type.GetType("StoryMode.Behaviors.FirstPhaseCampaignBehavior, StoryMode, Version=1.0.0.0, Culture=neutral");
+    private static readonly Type FirstPhaseCampaignBehaviorType = Type.GetType("StoryMode.Behaviors.FirstPhaseCampaignBehavior" + StoryModeAsmSpecifierSuffix);
 
     private static readonly MethodInfo FirstPhaseInstanceGetter = AccessTools.PropertyGetter(FirstPhaseType, "Instance");
 
@@ -43,7 +48,7 @@ namespace CommunityPatch.Patches {
 
     private static CampaignTime GetFirstPhaseFirstPhaseStartTime(object instance) => (CampaignTime) FirstPhaseFirstPhaseStartTimeGetter.Invoke(instance, null);
 
-    private static readonly Type SecondPhaseType = Type.GetType("StoryMode.StoryModePhases.SecondPhase, StoryMode, Version=1.0.0.0, Culture=neutral");
+    private static readonly Type SecondPhaseType = Type.GetType("StoryMode.StoryModePhases.SecondPhase" + StoryModeAsmSpecifierSuffix);
 
     private static readonly MethodInfo SecondPhaseInstanceGetter = AccessTools.PropertyGetter(SecondPhaseType, "Instance");
 
@@ -71,7 +76,7 @@ namespace CommunityPatch.Patches {
       if (FirstPhaseTimeLimitInYearsField == null)
         return false;
 
-      Type CampaignStoryModeType = Type.GetType("StoryMode.CampaignStoryMode, StoryMode, Version=1.0.0.0, Culture=neutral", false);
+      Type CampaignStoryModeType = Type.GetType("StoryMode.CampaignStoryMode" + StoryModeAsmSpecifierSuffix, false);
       if (CampaignStoryModeType == null)
         return false;
 


### PR DESCRIPTION
* Hide quest remaining days if it never expires

  * else we get very ugly text on the screen "-2147483648 days left" as quests never expiring were obviously not meant to have that displayed. This happens briefly between OnQuestStarted and the next hourly tick. Also can happen if another mod or part of the game changes the quest to never timeout.

![](https://i.imgur.com/L22Umnb.jpg)

* Explicitly show timeout on two quests that are part of FirstPhase but not in the associated namespace

  * MeetWithArzagosQuest and SupportKingdomQuest. They're not in the StoryMode.Behaviors.Quests.FirstPhase namespace but are actually part of the first phase.

* Ensure HourlyTick handlers don't remove each other

  * by registering them each with a seperate owner, as opposed to having them all be owned by the patch class. Previously each would remove their owner from active handlers after one hourly tick, but if they share owners, they may erase each other and certain handlers will not get called.
