### PR TITLE
add perk Logistics from tactics

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
     * Companion Cavalry
     * Tactical Superiority
     * One Step Ahead
+    * Logistics
 * Policies
   * Land Grants For Veterans
 * Feats

--- a/src/CommunityPatch/Patches/ExtraAmmoPerksPatch.cs
+++ b/src/CommunityPatch/Patches/ExtraAmmoPerksPatch.cs
@@ -58,6 +58,13 @@ namespace CommunityPatch.Patches {
         return;
 
       var hero = charObj.HeroObject;
+      
+      ApplyPerkToAgent(agent, 
+        (_, weapon) => canApplyPerk(hero, weapon), 
+        _ => ammoAmount);
+    }
+    
+    protected static void ApplyPerkToAgent(Agent agent, Func<Agent, WeaponComponentData, bool> canApplyPerk, Func<short, int> getAmmoIncrease) {
       var missionWeapons = (MissionWeapon[]) WeaponSlotsProperty.GetValue(agent.Equipment);
 
       for (var i = 0; i < missionWeapons.Length; i++) {
@@ -65,10 +72,11 @@ namespace CommunityPatch.Patches {
           continue;
 
         var weaponComponentData = missionWeapons[i].Weapons[0];
-        if (weaponComponentData == null || !canApplyPerk(hero, weaponComponentData))
+        if (weaponComponentData == null || !canApplyPerk(agent, weaponComponentData))
           continue;
 
-        var newMaxAmmo = (short) ((short) MaxAmmoField.GetValue(missionWeapons[i]) + ammoAmount);
+        var maxAmmo = (short) MaxAmmoField.GetValue(missionWeapons[i]);
+        var newMaxAmmo = (short) (maxAmmo + getAmmoIncrease(maxAmmo));
         object boxed = missionWeapons[i];
         AmmoField.SetValue(boxed, newMaxAmmo);
         MaxAmmoField.SetValue(boxed, newMaxAmmo);

--- a/src/CommunityPatch/Patches/Perks/Cunning/Tactics/LogisticsPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Tactics/LogisticsPatch.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
+using static System.Reflection.BindingFlags;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Tactics {
+
+  public class LogisticsPatch : ExtraAmmoPerksPatch<LogisticsPatch> {
+
+    private static readonly MethodInfo PatchMethodInfo = typeof(LogisticsPatch).GetMethod(nameof(Postfix), NonPublic | Static | DeclaredOnly);
+    
+    public override void Apply(Game game) {
+      if (Applied) return;
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo, postfix: new HarmonyMethod(PatchMethodInfo));
+      Applied = true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Postfix(Agent __instance) {
+      if (MyLeaderIsIntoLogistics(__instance)) 
+        ApplyPerkToAgent(__instance, CanApplyPerk, CalculateAmmoIncrease);
+    }
+
+    private static bool MyLeaderIsIntoLogistics(Agent agent) {
+      var leader = ((PartyGroupAgentOrigin) agent.Origin)?.Party.Leader;
+      if (leader == null || leader == agent.Character) return false;
+      return leader.GetPerkValue(DefaultPerks.Tactics.Logistics);
+    }
+
+    private static bool CanApplyPerk(Agent agent, WeaponComponentData weaponComponentData) {
+      var weaponClass = WeaponComponentData.GetItemTypeFromWeaponClass(weaponComponentData.WeaponClass);
+      
+      return weaponClass == ItemObject.ItemTypeEnum.Arrows ||
+        weaponClass == ItemObject.ItemTypeEnum.Bolts ||
+        weaponClass == ItemObject.ItemTypeEnum.Thrown;
+    }
+
+    private static int CalculateAmmoIncrease(short maxAmmo)
+      => (int) (maxAmmo * DefaultPerks.Tactics.Logistics.PrimaryBonus);
+  }
+
+}


### PR DESCRIPTION
Add perk logistics from Tactics tree. It should increase troops ammo by 20%. 

I have created a class that inherits from ExtraAmmoPerksPatch. However, since the buff is to the troops, not to the hero, I had to refactor ExtraAmmoPerksPatch to allow it. There is a new method to apply the perk to an Agent instead of Hero. 

I have made sure the other perks that increases ammo are still working.