### PR TITLE
add simulation damage perks

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
     * Companion Cavalry
     * Tactical Superiority
     * One Step Ahead
+    * Ambush Specialist
+    * Phalanx
+    * Hammer and Anvil
 * Policies
   * Land Grants For Veterans
 * Feats

--- a/src/CommunityPatch/Patches/Perks/Cunning/Tactics/AmbushSpecialistPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Tactics/AmbushSpecialistPatch.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using static System.Reflection.BindingFlags;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Tactics {
+
+  public class AmbushSpecialistPatch : SimulateHitPatch<AmbushSpecialistPatch> {
+    protected override string PerkId => "1fQxfkLX";
+
+    private static readonly MethodInfo PatchMethodInfo = typeof(AmbushSpecialistPatch).GetMethod(nameof(Postfix), Public | Static | DeclaredOnly);
+
+    public override void Apply(Game game) {
+      if (Applied) return;
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo, postfix: new HarmonyMethod(PatchMethodInfo));
+      Applied = true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Postfix(ref int __result, CharacterObject strikerTroop, PartyBase strikerParty) {
+      if (strikerTroop.IsArcher && IsInForest(strikerParty))
+        ApplyPerk(ref __result, ActivePatch.Perk, strikerParty);
+    }
+
+    private static bool IsInForest(PartyBase party) {
+      if (party.MobileParty == null) return false;
+      var faceTerrainType = Campaign.Current.MapSceneWrapper.GetFaceTerrainType(party.MobileParty.CurrentNavigationFace);
+      return faceTerrainType == TerrainType.Forest;
+    }
+  }
+}

--- a/src/CommunityPatch/Patches/Perks/Cunning/Tactics/HammerAndAnvilPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Tactics/HammerAndAnvilPatch.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using static System.Reflection.BindingFlags;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Tactics {
+
+  public class HammerAndAnvilPatch : SimulateHitPatch<HammerAndAnvilPatch> {
+    protected override string PerkId => "drLxFmla";
+
+    private static readonly MethodInfo PatchMethodInfo = typeof(HammerAndAnvilPatch).GetMethod(nameof(Postfix), Public | Static | DeclaredOnly);
+
+    public override void Apply(Game game) {
+      if (Applied) return;
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo, postfix: new HarmonyMethod(PatchMethodInfo));
+      Applied = true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Postfix(ref int __result, CharacterObject strikerTroop, CharacterObject strikedTroop, PartyBase strikerParty) {
+      if (strikerTroop.IsMounted && strikedTroop.IsArcher && !strikedTroop.IsMounted)
+        ApplyPerk(ref __result, ActivePatch.Perk, strikerParty);
+    }
+  }
+}

--- a/src/CommunityPatch/Patches/Perks/Cunning/Tactics/PhalanxPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Tactics/PhalanxPatch.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using static System.Reflection.BindingFlags;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Tactics {
+
+  public class PhalanxPatch : SimulateHitPatch<PhalanxPatch> {
+    protected override string PerkId => "5vs3qlQ8";
+
+    private static readonly MethodInfo PatchMethodInfo = typeof(PhalanxPatch).GetMethod(nameof(Postfix), Public | Static | DeclaredOnly);
+
+    public override void Apply(Game game) {
+      if (Applied) return;
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo, postfix: new HarmonyMethod(PatchMethodInfo));
+      Applied = true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Postfix(ref int __result, CharacterObject strikerTroop, CharacterObject strikedTroop, PartyBase strikerParty) {
+      if (strikerTroop.IsInfantry && strikedTroop.IsMounted)
+        ApplyPerk(ref __result, ActivePatch.Perk, strikerParty);
+    }
+  }
+}

--- a/src/CommunityPatch/Patches/Perks/Cunning/Tactics/SimulateHitPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Tactics/SimulateHitPatch.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.SandBox.GameComponents.Map;
+using TaleWorlds.Core;
+using static System.Reflection.BindingFlags;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Tactics {
+
+  public abstract class SimulateHitPatch<TPatch> : PatchBase<TPatch> where TPatch : PatchBase<TPatch> {
+    
+    public override bool Applied { get; protected set; }
+
+    protected static readonly MethodInfo TargetMethodInfo = typeof(DefaultCombatSimulationModel).GetMethod(nameof(DefaultCombatSimulationModel.SimulateHit), Public | Instance | DeclaredOnly);
+
+    private static readonly byte[][] Hashes = {
+      new byte[] {
+        // e1.1.0.225190
+        0x01, 0x52, 0x68, 0x11, 0x93, 0xB2, 0xA1, 0x81,
+        0x78, 0x07, 0xBE, 0x35, 0xBB, 0x79, 0x66, 0x53,
+        0x0B, 0x62, 0x52, 0xD2, 0x3F, 0xAA, 0xB5, 0xC0,
+        0x69, 0xBC, 0x13, 0xFF, 0x40, 0xD4, 0x49, 0x4C
+      }
+    };
+    
+    protected PerkObject Perk;
+    
+    public override void Reset()
+      => Perk = PerkObject.FindFirst(x => x.Name.GetID() == PerkId);
+    
+    public override IEnumerable<MethodBase> GetMethodsChecked() {
+      yield return TargetMethodInfo;
+    }
+
+    public override bool? IsApplicable(Game game) {
+      if (Perk == null) return false;
+      
+      var patchInfo = Harmony.GetPatchInfo(TargetMethodInfo);
+      if (AlreadyPatchedByOthers(patchInfo))
+        return false;
+
+      var hash = TargetMethodInfo.MakeCilSignatureSha256();
+      return hash.MatchesAnySha256(Hashes);
+    }
+    
+    protected static void ApplyPerk(ref int totalDamage, PerkObject perk, PartyBase strikerParty) {
+      if (strikerParty.LeaderHero?.GetPerkValue(perk) != true) return;
+      totalDamage += (int) (totalDamage * perk.PrimaryBonus);
+    }
+    
+    protected abstract string PerkId { get; }
+  }
+}

--- a/src/CommunityPatch/Patches/Perks/Cunning/Tactics/TacticalSuperiorityPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Tactics/TacticalSuperiorityPatch.cs
@@ -1,86 +1,25 @@
-using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
-using TaleWorlds.CampaignSystem.SandBox.GameComponents.Map;
 using TaleWorlds.Core;
-using TaleWorlds.Localization;
 using static System.Reflection.BindingFlags;
-using static CommunityPatch.HarmonyHelpers;
 
 namespace CommunityPatch.Patches.Perks.Cunning.Tactics {
 
-  public class TacticalSuperiorityPatch : PatchBase<TacticalSuperiorityPatch> {
-
-    public override bool Applied { get; protected set; }
-
-    private static readonly MethodInfo TargetMethodInfo = typeof(DefaultCombatSimulationModel).GetMethod(nameof(DefaultCombatSimulationModel.SimulateHit), Public | Instance | DeclaredOnly);
+  public class TacticalSuperiorityPatch : SimulateHitPatch<TacticalSuperiorityPatch> {
+    protected override string PerkId => "gBKb8DoH";
 
     private static readonly MethodInfo PatchMethodInfo = typeof(TacticalSuperiorityPatch).GetMethod(nameof(Postfix), Public | NonPublic | Static | DeclaredOnly);
 
-    public override IEnumerable<MethodBase> GetMethodsChecked() {
-      yield return TargetMethodInfo;
-    }
-
-    private PerkObject _perk;
-
-    private static readonly byte[][] Hashes = {
-      new byte[] {
-        // e1.1.0.225190
-        0x01, 0x52, 0x68, 0x11, 0x93, 0xB2, 0xA1, 0x81,
-        0x78, 0x07, 0xBE, 0x35, 0xBB, 0x79, 0x66, 0x53,
-        0x0B, 0x62, 0x52, 0xD2, 0x3F, 0xAA, 0xB5, 0xC0,
-        0x69, 0xBC, 0x13, 0xFF, 0x40, 0xD4, 0x49, 0x4C
-      }
-    };
-
-    public override void Reset()
-      => _perk = PerkObject.FindFirst(x => x.Name.GetID() == "gBKb8DoH");
-
-    public override bool? IsApplicable(Game game) {
-      if (_perk == null) return false;
-
-      var patchInfo = Harmony.GetPatchInfo(TargetMethodInfo);
-      if (AlreadyPatchedByOthers(patchInfo)) return false;
-
-      var hash = TargetMethodInfo.MakeCilSignatureSha256();
-      return hash.MatchesAnySha256(Hashes);
-    }
-
     public override void Apply(Game game) {
-      var textObjStrings = TextObject.ConvertToStringList(
-        new List<TextObject> {
-          _perk.Name,
-          _perk.Description
-        }
-      );
-
-      _perk.Initialize(
-        textObjStrings[0],
-        textObjStrings[1],
-        _perk.Skill,
-        (int) _perk.RequiredSkillValue,
-        _perk.AlternativePerk,
-        _perk.PrimaryRole, .05f,
-        _perk.SecondaryRole, _perk.SecondaryBonus,
-        _perk.IncrementType
-      );
-
       if (Applied) return;
-
       CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo, postfix: new HarmonyMethod(PatchMethodInfo));
       Applied = true;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void Postfix(ref int __result, PartyBase strikerParty) {
-      var perk = ActivePatch._perk;
-      if (strikerParty.LeaderHero?.GetPerkValue(perk) != true) return;
-
-      __result += (int) (__result * perk.PrimaryBonus);
-    }
-
+    public static void Postfix(ref int __result, PartyBase strikerParty) 
+      => ApplyPerk(ref __result, ActivePatch.Perk, strikerParty);
   }
-
 }


### PR DESCRIPTION
This PR adds three new simulation damage perks and refactor the existent one to make use of a base class. The base class is named SimulationHitPatch, and it has all the four patches basic implementation to avoid code repetition. 

The perks added are:
- Phalanx: "Your infantrymen deal 50% more damage to cavalry in simulations."
- Hammer and Anvil: "Your cavalry deal 50% more damage to archers in simulations"
- Ambush Specialist:  "Archers deliver 60% more damage in simulation in forests"

The one refactored is:
- Tactical Superiority: "Your soldiers deal %5 more damage in simulations"