### PR TITLE
add the perk Bait from tactics

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ This is going to be a mod that just fixes up some things in Mount &amp; Blade 2:
     * Companion Cavalry
     * Tactical Superiority
     * One Step Ahead
+    * Bait
 * Policies
   * Land Grants For Veterans
 * Feats

--- a/src/CommunityPatch/Patches/Perks/Cunning/Tactics/BaitPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Tactics/BaitPatch.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using Helpers;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
+using static System.Reflection.BindingFlags;
+using static CommunityPatch.HarmonyHelpers;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Tactics {
+
+  public class BaitPatch : PatchBase<BaitPatch> {
+
+    public override bool Applied { get; protected set; }
+    
+    private static readonly MethodInfo TargetMethodInfo = PlayerEncounterHelper.TargetMethodInfo;
+    private static readonly MethodInfo PatchMethodInfo = typeof(BaitPatch).GetMethod(nameof(Postfix), Public | NonPublic | Static | DeclaredOnly);
+    
+    public override IEnumerable<MethodBase> GetMethodsChecked() {
+      yield return TargetMethodInfo;
+    }
+
+    private PerkObject _perk;
+
+    private static readonly byte[][] Hashes = PlayerEncounterHelper.TargetHashes;
+
+    public override void Reset()
+      => _perk = PerkObject.FindFirst(x => x.Name.GetID() == "6MBoNlxj");
+
+    public override bool? IsApplicable(Game game) {
+      if (_perk == null) return false;
+
+      var patchInfo = Harmony.GetPatchInfo(TargetMethodInfo);
+      if (AlreadyPatchedByOthers(patchInfo)) return false;
+
+      var hash = TargetMethodInfo.MakeCilSignatureSha256();
+      return hash.MatchesAnySha256(Hashes);
+    }
+
+    public override void Apply(Game game) {
+      var textObjStrings = TextObject.ConvertToStringList(
+        new List<TextObject> {
+          _perk.Name,
+          _perk.Description
+        }
+      );
+
+      _perk.Initialize(
+        textObjStrings[0],
+        textObjStrings[1],
+        _perk.Skill,
+        (int) _perk.RequiredSkillValue,
+        _perk.AlternativePerk,
+        _perk.PrimaryRole, 30f,
+        _perk.SecondaryRole, _perk.SecondaryBonus,
+        SkillEffect.EffectIncrementType.AddFactor
+      );
+      
+      if (Applied) return;
+      CommunityPatchSubModule.Harmony.Patch(TargetMethodInfo, postfix: new HarmonyMethod(PatchMethodInfo));
+      Applied = true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Postfix(ref PlayerEncounter __instance, ref List<MobileParty> partiesToJoinOurSide, ref List<MobileParty> partiesToJoinEnemySide) {
+      var ourParty = PartyBase.MainParty;
+      var encounterParty = PlayerEncounterHelper.GetEncounteredParty(__instance);
+
+      AddNearbyAlliesToParty(ourParty, encounterParty, partiesToJoinOurSide);
+      AddNearbyAlliesToParty(encounterParty, ourParty, partiesToJoinEnemySide, true);
+      
+      partiesToJoinEnemySide = partiesToJoinEnemySide.Distinct().ToList();
+      partiesToJoinOurSide = partiesToJoinOurSide.Distinct().ToList();
+    }
+
+    private static void AddNearbyAlliesToParty(PartyBase party, PartyBase enemyParty, List<MobileParty> alliesFound,  bool allyMustBeAbleToAttack = false) {
+      var isSiege = IsSiegeEncounter();
+      var position2D = GetEncounterPosition(isSiege);
+      var radius = CalculateCallToArmsRadius(party, isSiege);
+
+      var possibleAllies = PlayerEncounterHelper.FindPartiesAroundPosition(position2D, radius);
+      
+      foreach (var possibleAlly in possibleAllies) {
+        if (!IsAlly(party, enemyParty, possibleAlly, allyMustBeAbleToAttack)) continue;
+
+        alliesFound.Add(possibleAlly);
+          
+        if (possibleAlly.Army != null && possibleAlly.Army.LeaderParty == possibleAlly)
+          alliesFound.AddRange(possibleAlly.Army.LeaderParty.AttachedParties);
+      }
+    }
+    
+    private static bool IsSiegeEncounter() 
+      => PlayerEncounter.EncounteredParty != null && 
+        PlayerEncounter.EncounteredParty.IsMobile && 
+        PlayerEncounter.EncounteredParty.MobileParty.BesiegedSettlement != null || 
+        MobileParty.MainParty.BesiegedSettlement != null;
+
+    private static Vec2 GetEncounterPosition(bool isSiegeEvent) {
+      if (!isSiegeEvent) return MobileParty.MainParty.Position2D;
+
+      if (PlayerEncounter.EncounteredParty?.IsMobile == true && PlayerEncounter.EncounteredParty?.MobileParty?.BesiegedSettlement != null)
+      {
+        if (PlayerEncounter.EncounteredParty.SiegeEvent?.BesiegerCamp?.BesiegerParty != null)
+          return PlayerEncounter.EncounteredParty.SiegeEvent.BesiegerCamp.BesiegerParty.Position2D;
+      }
+      else if (MobileParty.MainParty.BesiegerCamp?.BesiegerParty != null)
+        return MobileParty.MainParty.BesiegerCamp.BesiegerParty.Position2D;
+
+      return MobileParty.MainParty.Position2D;
+    }
+    
+    private static float CalculateCallToArmsRadius(PartyBase party, bool isSiege)
+    {
+      var baseRadius = 3f * (isSiege ? 1.5f : 1f);
+      var finalRadius = new ExplainedNumber(baseRadius);
+      
+      if (party.MobileParty != null)
+        PerkHelper.AddPerkBonusForParty(ActivePatch._perk, party.MobileParty, ref finalRadius);
+      
+      return finalRadius.ResultNumber;
+    }
+    
+    private static bool IsAlly(PartyBase party, PartyBase enemyParty, MobileParty possibleAlly, bool allyMustBeAbleToAttack)
+    {
+      if (!IsAValidPossibleAlly(party, possibleAlly)) 
+        return false;
+      
+      if (!MapEventHelper.PartyCanJoinSideOf(possibleAlly, party, enemyParty)) 
+        return false;
+
+      return !allyMustBeAbleToAttack || PlayerEncounterHelper.CanPartyAttack(possibleAlly, enemyParty.MobileParty);
+    }
+
+    private static bool IsAValidPossibleAlly(PartyBase party, MobileParty possibleAlly)
+      => possibleAlly != MobileParty.MainParty && possibleAlly != PlayerEncounter.EncounteredParty.MobileParty && possibleAlly.MapEvent == null && possibleAlly.IsActive && (possibleAlly.BesiegedSettlement == null || (MobileParty.MainParty.MapEvent != null && MobileParty.MainParty.MapEvent.IsSiege && MobileParty.MainParty.MapEvent.MapEventSettlement == possibleAlly.BesiegedSettlement) || (MobileParty.MainParty.Army != null && MobileParty.MainParty.Army.LeaderParty.AttachedParties.Contains(possibleAlly))) && (possibleAlly.Army == null || !possibleAlly.Army.LeaderParty.AttachedParties.Contains(possibleAlly)) && (possibleAlly.CurrentSettlement == null || MobileParty.MainParty.BesiegedSettlement == possibleAlly.CurrentSettlement || (party.MobileParty != null && possibleAlly.CurrentSettlement == party.MobileParty.CurrentSettlement));
+  }
+
+}

--- a/src/CommunityPatch/Patches/Perks/Cunning/Tactics/PlayerEncounterHelper.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Tactics/PlayerEncounterHelper.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Library;
+using static System.Reflection.BindingFlags;
+
+namespace CommunityPatch.Patches.Perks.Cunning.Tactics {
+
+  public static class PlayerEncounterHelper {
+    private static readonly Type PlayerEncounterType = typeof(PlayerEncounter);
+    private static readonly Type MobilePartyType = typeof(MobileParty);
+    private static readonly Type CampaignType = typeof(Campaign);
+    private static readonly FieldInfo EncounteredParty = PlayerEncounterType.GetField("_encounteredParty", NonPublic | Instance | DeclaredOnly);
+    private static readonly PropertyInfo CampaignMobilePartyLocator = CampaignType.GetProperty("MobilePartyLocator", NonPublic | Instance | DeclaredOnly);
+    private static readonly MethodInfo MobilePartyCanAttack = MobilePartyType.GetMethod("CanAttack", NonPublic | Instance | DeclaredOnly);
+    public static readonly MethodInfo TargetMethodInfo = PlayerEncounterType.GetMethod(nameof(PlayerEncounter.FindPartiesWhoWillJoinEvent), Public | Instance | DeclaredOnly);
+
+    public static readonly byte[][] TargetHashes = {
+      new byte[] {
+        // e1.2.1.226961
+        0xAD, 0xB4, 0x55, 0x5E, 0xCD, 0xC4, 0xE6, 0x5E,
+        0x14, 0x60, 0x91, 0x82, 0xFD, 0xB5, 0xE2, 0x5C,
+        0x65, 0xF0, 0x0D, 0x10, 0xDA, 0x79, 0x96, 0x7C,
+        0xBC, 0x50, 0x29, 0x94, 0xF0, 0xB5, 0xE7, 0x76
+      }
+    };
+    
+    public static PartyBase GetEncounteredParty(PlayerEncounter encounter)
+      => (PartyBase) EncounteredParty.GetValue(encounter);
+    
+    public static bool CanPartyAttack(MobileParty party, MobileParty target)
+      => (bool) MobilePartyCanAttack.Invoke(party, new object[] {target});
+    
+    public static IEnumerable<MobileParty> FindPartiesAroundPosition(Vec2 position2D, float radius) {
+      var locator = CampaignMobilePartyLocator.GetValue(Campaign.Current);
+      var locatorType = locator.GetType();
+      var findPartiesMethod = locatorType.GetMethod("FindPartiesAroundPosition", NonPublic | Instance | DeclaredOnly, null, new[] {typeof(Vec2), typeof(float)}, new ParameterModifier[] { }); 
+      var results = findPartiesMethod?.Invoke(locator, new object[] {position2D, radius});
+      return (IEnumerable<MobileParty>) results;
+    }
+  }
+
+}


### PR DESCRIPTION
This PR adds the perk bait, which should increase reinforcement range by 30% (party member).

In order to do so, I have patched the method responsible for bringing the nearby troops (both ally and enemy) into battle. Since the range values were hardcoded in a very big method, I had the idea to make a postfix that would search for nearby parties a second time, but this time with the range increased.

The down side is that the scan is done twice, however, since this is just a player feature that triggers only when his/her battle is going to start, it shouldn't be a performance problem. 