### PR TITLE
fix IntelliSense completion

### DIFF
--- a/src/CommunityPatch/CommunityPatch.csproj
+++ b/src/CommunityPatch/CommunityPatch.csproj
@@ -107,7 +107,7 @@
         <Message Importance="high" Text="SCI Supported: $(SourceControlInformationFeatureSupported)" />
         <Message Importance="high" Text="SCI Version: $(SourceRevisionId)" />
         <PropertyGroup>
-            <SourceRevisionId>$(SourceRevisionId.Substring(0,7))</SourceRevisionId>
+            <SourceRevisionId Condition="'$(DesignTimeBuild)' != 'true'">$(SourceRevisionId.Substring(0,7))</SourceRevisionId>
         </PropertyGroup>
         <Message Importance="high" Text="Shortened SCI Version: $(SourceRevisionId)" />
     </Target>


### PR DESCRIPTION
This fixes #261.
@iPherian _how on earth did you narrow it down? :smile:_ 
Anyway, if IntelliSense for some reason doesn't like `SourceRevisionId` property, a `$(DesignTimeBuild)` condition should fix it without breaking the "real" builds.