### PR TITLE
Disable trampler patch in custom battles

### DIFF
--- a/src/CommunityPatch/Patches/Perks/Endurance/Riding/TramplerPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Endurance/Riding/TramplerPatch.cs
@@ -69,6 +69,10 @@ namespace CommunityPatch.Patches.Perks.Endurance.Riding {
     }
 
     public override bool? IsApplicable(Game game) {
+      if (Perk == null) {
+        return false;
+      }
+      
       if (TargetMethodInfo == null)
         return false;
 

--- a/src/CommunityPatch/Patches/Perks/Endurance/Riding/TramplerPatch2.cs
+++ b/src/CommunityPatch/Patches/Perks/Endurance/Riding/TramplerPatch2.cs
@@ -61,6 +61,10 @@ namespace CommunityPatch.Patches.Perks.Endurance.Riding {
     }
 
     public override bool? IsApplicable(Game game) {
+      if (Perk == null) {
+        return false;
+      }
+      
       if (OverloadedTargetMethodInfo == null)
         return false;
 


### PR DESCRIPTION
Quickfix that skips Trampler patches when loaded in custom battle on 1.3.1 and 1.4.0.
Although, this doesn't resolve the lack of perks in this game mode.
#293 #306 
