### PR TITLE
Add base for Concealed Perks

### DIFF
--- a/src/CommunityPatch/Patches/EquipDraggedNonCivilianItemPatch.cs
+++ b/src/CommunityPatch/Patches/EquipDraggedNonCivilianItemPatch.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using CommunityPatch;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.ViewModelCollection;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using static System.Reflection.BindingFlags;
+using static CommunityPatch.PatchApplicabilityHelper;
+
+namespace Patches {
+  public static class EquipDraggedNonCivilianItemPatch {
+
+    internal static readonly MethodInfo UpdateCurrentCharacterIfPossibleMethodInfo = typeof(SPInventoryVM)
+      .GetMethod("UpdateCurrentCharacterIfPossible", NonPublic | Instance | DeclaredOnly);
+
+    internal static readonly MethodInfo InitializeInventoryMethodInfo = typeof(SPInventoryVM)
+      .GetMethod("InitializeInventory", NonPublic | Instance | DeclaredOnly);
+    
+    internal static readonly MethodInfo AfterTransferMethodInfo = typeof(SPInventoryVM)
+      .GetMethod("AfterTransfer", NonPublic | Instance | DeclaredOnly);
+    
+    internal static readonly MethodInfo SetIsCivilianItemMethodInfo = typeof(SPItemVM)
+      .GetMethod("set_IsCivilianItem", Public | Instance | DeclaredOnly);
+
+    internal static readonly FieldInfo RightItemListVmFieldInfo = typeof(SPInventoryVM)
+      .GetField("_rightItemListVM", NonPublic | Instance | DeclaredOnly);
+    
+    internal static readonly FieldInfo LeftItemListVmFieldInfo = typeof(SPInventoryVM)
+      .GetField("_leftItemListVM", NonPublic | Instance | DeclaredOnly);
+
+    internal static readonly FieldInfo CurrentCharacterFieldInfo = typeof(SPInventoryVM)
+      .GetField("_currentCharacter", NonPublic | Instance | DeclaredOnly);
+
+    internal static readonly byte[][] UpdateCurrentCharacterIfPossibleHashes = {
+      new byte[] {
+        // e1.3.1.228624
+        0x95, 0xA4, 0x67, 0xBA, 0x07, 0x7D, 0x7D, 0xCB,
+        0x77, 0xD3, 0x3B, 0x9F, 0xFD, 0xDD, 0x20, 0xB3,
+        0x83, 0xC2, 0xCD, 0xD0, 0xBA, 0x95, 0xCC, 0xF3,
+        0x27, 0xB3, 0x3D, 0xC5, 0x90, 0x6B, 0x4D, 0x22
+      },
+      new byte[] {
+        // e1.4.1.229326
+        0x57, 0x69, 0x90, 0xAC, 0xC2, 0x34, 0x60, 0xFE,
+        0xAA, 0x66, 0x9C, 0x70, 0xBE, 0xBA, 0x87, 0xCC,
+        0xE1, 0x97, 0x73, 0x42, 0xDA, 0x8D, 0x76, 0xB9,
+        0x32, 0xA8, 0x0A, 0xEB, 0x02, 0xC0, 0x2E, 0xB2
+      }
+    };
+    
+    internal static readonly byte[][] InitializeInventoryHashes = {
+      new byte[] {
+        // e1.3.1.228624
+        0x64, 0x60, 0xEB, 0xE8, 0x33, 0x13, 0x5B, 0xB6,
+        0x6F, 0xF2, 0x00, 0x4B, 0x86, 0x4A, 0x00, 0x36,
+        0x8A, 0x5A, 0x4A, 0xB8, 0x0C, 0x63, 0x8E, 0x7C,
+        0x2D, 0x20, 0xB1, 0x56, 0x65, 0x9F, 0x43, 0x38
+      },
+      new byte[] {
+        // e1.4.1.229326
+        0x09, 0x71, 0x08, 0xF9, 0x66, 0xA7, 0x3A, 0xBA,
+        0x6F, 0x89, 0xAD, 0x79, 0xCD, 0x45, 0xFE, 0x93,
+        0xA0, 0x1F, 0x38, 0x31, 0xB3, 0xEB, 0x22, 0x3E,
+        0x2B, 0x3B, 0xA7, 0x5C, 0x5B, 0xF9, 0x27, 0xE0
+      }
+    };
+    
+    internal static readonly byte[][] AfterTransferHashes = {
+      new byte[] {
+        // e1.3.1.228624
+        0x25, 0x15, 0x66, 0x66, 0xB9, 0x1A, 0x40, 0xFA,
+        0x42, 0x17, 0x88, 0x63, 0x6D, 0x89, 0xC9, 0x05,
+        0x6C, 0x2F, 0x66, 0x2E, 0x2E, 0x97, 0xBA, 0xF7,
+        0x2E, 0xDA, 0x95, 0x93, 0x09, 0xE3, 0xCD, 0xC9
+      },
+      new byte[] {
+        // e1.4.0.229335
+        0x25, 0x15, 0x66, 0x66, 0xB9, 0x1A, 0x40, 0xFA,
+        0x42, 0x17, 0x88, 0x63, 0x6D, 0x89, 0xC9, 0x05,
+        0x6C, 0x2F, 0x66, 0x2E, 0x2E, 0x97, 0xBA, 0xF7,
+        0x2E, 0xDA, 0x95, 0x93, 0x09, 0xE3, 0xCD, 0xC9
+      },
+      new byte[] {
+        // e1.4.1.229326
+        0xE2, 0x6A, 0x91, 0x63, 0xC2, 0xA0, 0x16, 0x8D,
+        0x7B, 0xF3, 0x60, 0x38, 0x11, 0x23, 0x4E, 0x6F,
+        0x41, 0x9D, 0xD0, 0x7F, 0x2F, 0xB8, 0xCB, 0xA8,
+        0xDA, 0x57, 0x02, 0x03, 0xB9, 0xA9, 0x6C, 0x8C
+      }
+    };
+
+  }
+
+  public abstract class EquipDraggedNonCivilianItemPatch<TPatch> : PerkPatchBase<TPatch> where TPatch : EquipDraggedNonCivilianItemPatch<TPatch> {
+
+    private static MethodInfo UpdateCurrentCharacterIfPossibleMethodInfo => EquipDraggedNonCivilianItemPatch.UpdateCurrentCharacterIfPossibleMethodInfo;
+    
+    private static MethodInfo InitializeInventoryMethodInfo => EquipDraggedNonCivilianItemPatch.InitializeInventoryMethodInfo;
+    
+    private static MethodInfo AfterTransferMethodInfo => EquipDraggedNonCivilianItemPatch.AfterTransferMethodInfo;
+    
+    private static MethodInfo SetIsCivilianItemMethodInfo => EquipDraggedNonCivilianItemPatch.SetIsCivilianItemMethodInfo;
+
+    private static FieldInfo RightItemListVmFieldInfo => EquipDraggedNonCivilianItemPatch.RightItemListVmFieldInfo;
+    
+    private static FieldInfo LeftItemListVmFieldInfo => EquipDraggedNonCivilianItemPatch.LeftItemListVmFieldInfo;
+
+    private static FieldInfo CurrentCharacterFieldInfo => EquipDraggedNonCivilianItemPatch.CurrentCharacterFieldInfo;
+    
+    private MethodInfo UpdateCurrentCharacterIfPossiblePrefixMethodInfo => GetType()
+      .GetMethod("UpdateCurrentCharacterIfPossiblePrefix", NonPublic | Static | DeclaredOnly);
+    
+    private MethodInfo UpdateCurrentCharacterIfPossiblePostfixMethodInfo => GetType()
+          .GetMethod("UpdateCurrentCharacterIfPossiblePostfix", NonPublic | Static | DeclaredOnly);
+    
+    private MethodInfo InitializeInventoryPostfixMethodInfo => GetType()
+      .GetMethod("InitializeInventoryPostfix", NonPublic | Static | DeclaredOnly);
+    
+    private MethodInfo AfterTransferPostfixMethodInfo => GetType()
+      .GetMethod("AfterTransferPostfix", NonPublic | Static | DeclaredOnly);
+
+    private static byte[][] UpdateCurrentCharacterIfPossibleHashes => EquipDraggedNonCivilianItemPatch.UpdateCurrentCharacterIfPossibleHashes;
+    
+    private static byte[][] InitializeInventoryHashes => EquipDraggedNonCivilianItemPatch.InitializeInventoryHashes;
+    
+    private static byte[][] AfterTransferHashes => EquipDraggedNonCivilianItemPatch.AfterTransferHashes;
+
+    protected EquipDraggedNonCivilianItemPatch(string perkId) : base(perkId) {
+    }
+    
+    public override IEnumerable<MethodBase> GetMethodsChecked() {
+      yield return UpdateCurrentCharacterIfPossibleMethodInfo;
+      yield return InitializeInventoryMethodInfo;
+      yield return AfterTransferMethodInfo;
+    }
+    
+    public override bool Applied { get; protected set; }
+
+    public override void Apply(Game game) {
+      CommunityPatchSubModule.Harmony.Patch(InitializeInventoryMethodInfo, postfix: new HarmonyMethod(InitializeInventoryPostfixMethodInfo));
+      CommunityPatchSubModule.Harmony.Patch(AfterTransferMethodInfo, postfix: new HarmonyMethod(AfterTransferPostfixMethodInfo));
+      CommunityPatchSubModule.Harmony.Patch(UpdateCurrentCharacterIfPossibleMethodInfo,
+        prefix: new HarmonyMethod(UpdateCurrentCharacterIfPossiblePrefixMethodInfo),
+        postfix: new HarmonyMethod(UpdateCurrentCharacterIfPossiblePostfixMethodInfo));
+
+      Applied = true;
+    }
+
+    private void PrintMethodNotFoundByReflectionError(String typeName)
+      => CommunityPatchSubModule.Error
+        ($"{nameof(EquipDraggedNonCivilianItemPatch)}: Couldn't find {typeName} by reflection.");
+    
+    public override bool? IsApplicable(Game game) {
+      if (UpdateCurrentCharacterIfPossibleMethodInfo == null) {
+        PrintMethodNotFoundByReflectionError(nameof(UpdateCurrentCharacterIfPossibleMethodInfo));
+        return false;
+      }
+      
+      if (InitializeInventoryMethodInfo == null) {
+        PrintMethodNotFoundByReflectionError(nameof(InitializeInventoryMethodInfo));
+        return false;
+      }
+      
+      if (AfterTransferMethodInfo == null) {
+        PrintMethodNotFoundByReflectionError(nameof(AfterTransferMethodInfo));
+        return false;
+      }
+      
+      if (SetIsCivilianItemMethodInfo == null) {
+        PrintMethodNotFoundByReflectionError(nameof(SetIsCivilianItemMethodInfo));
+        return false;
+      }
+
+      if (RightItemListVmFieldInfo == null) {
+        PrintMethodNotFoundByReflectionError(nameof(RightItemListVmFieldInfo));
+        return false;
+      }
+      
+      if (LeftItemListVmFieldInfo == null) {
+        PrintMethodNotFoundByReflectionError(nameof(LeftItemListVmFieldInfo));
+        return false;
+      }
+
+      if (CurrentCharacterFieldInfo == null) {
+        PrintMethodNotFoundByReflectionError(nameof(CurrentCharacterFieldInfo));
+        return false;
+      }
+      
+      if (UpdateCurrentCharacterIfPossiblePrefixMethodInfo == null) {
+        PrintMethodNotFoundByReflectionError(nameof(UpdateCurrentCharacterIfPossiblePrefixMethodInfo));
+        return false;
+      }
+        
+      if (UpdateCurrentCharacterIfPossiblePostfixMethodInfo == null) {
+        PrintMethodNotFoundByReflectionError(nameof(UpdateCurrentCharacterIfPossiblePostfixMethodInfo));
+        return false;
+      } 
+        
+      if (InitializeInventoryPostfixMethodInfo == null) {
+        PrintMethodNotFoundByReflectionError(nameof(InitializeInventoryPostfixMethodInfo));
+        return false;
+      }
+      
+      if (AfterTransferPostfixMethodInfo == null) {
+        PrintMethodNotFoundByReflectionError(nameof(InitializeInventoryPostfixMethodInfo));
+        return false;
+      }
+
+      if (!IsTargetPatchable(UpdateCurrentCharacterIfPossibleMethodInfo, UpdateCurrentCharacterIfPossibleHashes)) {
+        return false;
+      }
+      
+      if (!IsTargetPatchable(InitializeInventoryMethodInfo, InitializeInventoryHashes)) {
+        return false;
+      }
+      
+      if (!IsTargetPatchable(AfterTransferMethodInfo, AfterTransferHashes)) {
+        return false;
+      }
+
+      return base.IsApplicable(game);
+    }
+
+    private static void MapLeftAndRightInventory(SPInventoryVM spInventoryVm, Action<SPItemVM> itemMapper) {
+      var rightItemListVm = (MBBindingList<SPItemVM>) RightItemListVmFieldInfo.GetValue(spInventoryVm);
+      var leftItemListVm = (MBBindingList<SPItemVM>) LeftItemListVmFieldInfo.GetValue(spInventoryVm);
+
+      if (rightItemListVm == null || leftItemListVm == null) {
+        return;
+      }
+      
+      leftItemListVm.ApplyActionOnAllItems(itemMapper);
+      rightItemListVm.ApplyActionOnAllItems(itemMapper);
+    }
+
+    private static void NonCivilianPerkItemsEquipableState(SPInventoryVM spInventoryVm, Func<SPItemVM, bool> isItemApplicableToPerk, bool state) {
+
+      Action<SPItemVM> makeCivilianItemUnequipable = item => {
+        var isCivilian = item?.ItemRosterElement.EquipmentElement.Item?.IsCivilian ?? false;
+        if (isItemApplicableToPerk(item) && !isCivilian) {
+          SetIsCivilianItemMethodInfo.Invoke(item, new object[] { state });
+        }
+      };
+      
+      MapLeftAndRightInventory(spInventoryVm, makeCivilianItemUnequipable);
+    }
+
+    private static void MakeNonCivilianPerkItemsUnequipable(SPInventoryVM spInventoryVm, Func<SPItemVM, bool> isItemApplicableToPerk)
+      => NonCivilianPerkItemsEquipableState(spInventoryVm, isItemApplicableToPerk, false);
+
+    private static void MakeNonCivilianPerkItemsEquipable(SPInventoryVM spInventoryVm, Func<SPItemVM, bool> isItemApplicableToPerk)
+      => NonCivilianPerkItemsEquipableState(spInventoryVm, isItemApplicableToPerk, true);
+    
+    private static bool CharacterHasPerk(CharacterObject characterObject) {
+      return characterObject != null && characterObject.GetPerkValue(ActivePatch.Perk);
+    }
+
+    private static void FlipEquipableStateOfNonCivilianPerkItemsIfCharacterHasPerkOrNot(SPInventoryVM spInventoryVm, CharacterObject previousCharacter, Func<SPItemVM, bool> isItemApplicableToPerk) {
+      if (CharacterHasPerk(previousCharacter)) {
+        MakeNonCivilianPerkItemsEquipable(spInventoryVm, isItemApplicableToPerk);
+      }
+      else {
+        MakeNonCivilianPerkItemsUnequipable(spInventoryVm, isItemApplicableToPerk);
+      }
+    }
+    
+    protected static void FlipEquipableStateOfNonCivilianPerkItemsIfDisplayedCharacterHasPerkOrNot(SPInventoryVM spInventoryVm, Func<SPItemVM, bool> isItemApplicableToPerk) {
+      var currentCharacter = (CharacterObject)CurrentCharacterFieldInfo.GetValue(spInventoryVm);
+      if (currentCharacter != null) {
+        FlipEquipableStateOfNonCivilianPerkItemsIfCharacterHasPerkOrNot(spInventoryVm, currentCharacter, isItemApplicableToPerk);
+      }
+    }
+    
+    protected static void StorePreviousCharacter(SPInventoryVM spInventoryVm, out CharacterObject currentCharacter) {
+      currentCharacter = (CharacterObject) CurrentCharacterFieldInfo.GetValue(spInventoryVm);
+    }
+
+    protected static void KeepEquipableStateOfNonCivilianPerkItemsIfPreviousAndDisplayedCharacterHavePerkOrNot(SPInventoryVM spInventoryVm, CharacterObject previousCharacter, Func<SPItemVM, bool> isItemApplicableToPerk) {
+      var displayedCharacter = (CharacterObject) CurrentCharacterFieldInfo.GetValue(spInventoryVm);
+      var displayedCharacterHasPerk = CharacterHasPerk(displayedCharacter);
+      
+      // If the previous character in the inventory has the perk, then the non civilian items should not be updated if the new shown character also has the perk.
+      // Non civilian items should not be updated if both characters do not have the perk.
+      // If the player has no other hero in its army, then the previous and displayed character will be the same character. This use case falls into the previous case.
+      if (previousCharacter == null || displayedCharacter == null || !(CharacterHasPerk(previousCharacter) ^ displayedCharacterHasPerk)) {
+        return;
+      }
+      FlipEquipableStateOfNonCivilianPerkItemsIfCharacterHasPerkOrNot(spInventoryVm, displayedCharacter, isItemApplicableToPerk);
+    }
+
+  }
+
+}


### PR DESCRIPTION
#284 
Non civilian items can be equipped when in civilian mode in the inventory screen.

When switching characters, or transferring items from both left and right inventories or resetting the transactions, the player should be able to equip the displayed character with the items described by the perk.

Multiple patches can be added to allow more items to be available in civilian mode if the displayed character has all perks.

If multiple patches describe the same items, there could be some collision issues. But this shouldn't occur anytime soon with the way perks are thought out.

This should be compatible with :
- **e1.3.1**.228624
- **e1.4.0**.229335
- Beta **e1.4.1**.229326
