### PR TITLE
Fix UI for Tier 11 Smithing perks

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ If your Bannerlord or local repo are in a different place, you can change the pr
 * [iPherian](https://www.nexusmods.com/users/86335488)
 * [miguelcjalmeida](https://github.com/miguelcjalmeida)
 * [Eagle](https://github.com/JoeFwd) ([Discord](https://discordapp.com/users/242802595347955715))
+* [fnzr](https://github.com/fnzr)
 
 ##### Others
 * Xaphedo for providing the banner art

--- a/src/CommunityPatch/Patches/Perks/Endurance/Smithing/LegendarySmithUiPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Endurance/Smithing/LegendarySmithUiPatch.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using CommunityPatch;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Localization;
+
+namespace Patches.Perks.Endurance.Smithing {
+
+  public class LegendarySmithUiPatch : PatchBase<LegendarySmithUiPatch> {
+
+    public override bool Applied { get; protected set; }
+
+    public override IEnumerable<MethodBase> GetMethodsChecked()
+      => Enumerable.Empty<MethodBase>();
+
+    private PerkObject _perkSiegeExpert;
+
+    private PerkObject _perkLegendarySmith;
+
+    public override void Reset() {
+      _perkLegendarySmith = PerkObject.FindFirst(x => x.Name.GetID() == "f4lnEplc");
+      _perkSiegeExpert = PerkObject.FindFirst(x => x.Name.GetID() == "I8ZZagQU");
+    }
+
+    public override bool? IsApplicable(Game game) {
+      if (_perkLegendarySmith == null || _perkSiegeExpert == null) {
+        return false;
+      }
+
+      if (_perkLegendarySmith.AlternativePerk == _perkSiegeExpert && _perkSiegeExpert.AlternativePerk == _perkLegendarySmith) {
+        return false;
+      }
+
+      return true;
+    }
+
+    public override void Apply(Game game) {
+      var textObjStrings = TextObject.ConvertToStringList(
+        new List<TextObject> {
+          _perkLegendarySmith.Name,
+          _perkLegendarySmith.Description
+        }
+      );
+
+      _perkLegendarySmith.Initialize(
+        textObjStrings[0],
+        textObjStrings[1],
+        _perkLegendarySmith.Skill,
+        (int) _perkLegendarySmith.RequiredSkillValue,
+        _perkSiegeExpert,
+        _perkLegendarySmith.PrimaryRole, _perkLegendarySmith.PrimaryBonus,
+        _perkLegendarySmith.SecondaryRole, _perkLegendarySmith.SecondaryBonus,
+        _perkLegendarySmith.IncrementType
+      );
+      Applied = true;
+    }
+  }
+}


### PR DESCRIPTION
Fix either Legendary Smith or Siege Expert not being selectable by the player.
This is a UI only fix and doesn't implement the Siege Expert perk.