### PR TITLE
Fix crash when applying no option.

### DIFF
--- a/src/CommunityPatch/CommunityPatchSubModule.Options.cs
+++ b/src/CommunityPatch/CommunityPatchSubModule.Options.cs
@@ -101,6 +101,7 @@ namespace CommunityPatch {
     }
 
     private void HandleOptionChoice(List<InquiryElement> list) {
+      if (list.IsEmpty()) return;
       var selected = (string) list[0].Identifier;
       switch (selected) {
         case nameof(DisableIntroVideo):


### PR DESCRIPTION
Window closes with no effect if "Apply" is clicked with no option selected.
Just an empty check before entering the switch.  Solves #337 