### PR TITLE
use correct perk in Roguery.MerryMenPatch

### DIFF
--- a/src/CommunityPatch/Patches/PerkPatchBase.cs
+++ b/src/CommunityPatch/Patches/PerkPatchBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using CommunityPatchAnalyzer;
 using JetBrains.Annotations;
@@ -14,13 +15,22 @@ namespace CommunityPatch {
     [PublicAPI]
     public string PerkId { get; }
 
+    private readonly Func<PerkObject, bool> _finder;
+
     private PerkObject _perk;
 
     [PublicAPI]
     public string PerkName => LocalizedTextManager.GetTranslatedText(BannerlordConfig.Language, PerkId);
 
-    protected PerkPatchBase(string perkId)
-      => PerkId = perkId;
+    protected PerkPatchBase(string perkId) {
+      PerkId = perkId;
+      _finder = perk => perk.Name.GetID() == perkId;
+    }
+
+    protected PerkPatchBase(string perkId, Func<PerkObject, bool> disambiguation) {
+      PerkId = perkId;
+      _finder = perk => perk.Name.GetID() == perkId && disambiguation(perk);
+    }
 
     [PublicAPI]
     [CanBeNull]
@@ -30,7 +40,7 @@ namespace CommunityPatch {
         if (_perk != null)
           return _perk;
 
-        _perk = PerkObjectHelpers.Load(PerkId);
+        _perk = PerkObjectHelpers.Load(_finder);
 
         if (_perk == null) {
           //throw new KeyNotFoundException($"Can't find the {PerkName} ({_perkId}) perk.");

--- a/src/CommunityPatch/Patches/Perks/Cunning/Roguery/MerryMenPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Cunning/Roguery/MerryMenPatch.cs
@@ -33,7 +33,7 @@ namespace CommunityPatch.Patches.Perks.Cunning.Roguery {
       }
     };
 
-    public MerryMenPatch() : base("ssljPTUr") {
+    public MerryMenPatch() : base("ssljPTUr", perk => perk.StringId == "RogueryMerryMen") {
     }
 
     public override bool? IsApplicable(Game game) {

--- a/src/CommunityPatch/PerkObjectHelpers.cs
+++ b/src/CommunityPatch/PerkObjectHelpers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using JetBrains.Annotations;
 using TaleWorlds.CampaignSystem;
@@ -7,15 +8,19 @@ namespace CommunityPatch {
   internal static class PerkObjectHelpers {
 
     [CanBeNull]
-    public static PerkObject Load(string id) {
+    public static PerkObject Load(string id)
+      => Load(x => x.Name.GetID() == id);
+
+    [CanBeNull]
+    public static PerkObject Load(Func<PerkObject, bool> predicate) {
       try {
         // campaign scenarios
-        return PerkObject.FindFirst(x => x.Name.GetID() == id);
+        return PerkObject.FindFirst(predicate);
       }
       catch {
         // custom battle & other non-campaign scenarios
         try {
-          return DefaultPerks.GetAllPerks().FirstOrDefault(x => x.Name.GetID() == id);
+          return DefaultPerks.GetAllPerks().FirstOrDefault(predicate);
         }
         catch {
           // oof


### PR DESCRIPTION
Currently Roguery.MerryMenPatch is referring to BowMerryMen perk, because it has the same name as RogueryMerryMen perk.
This RogueryMerryMen is indeed rogue as it doesn't even have a property in DefaultPerks so had to find it by StringId.
The workaround is quite ugly but I could not find any better way, maybe you can help with this?
Btw TW has also BowMountedArcher and RidingMountedArcher with the same problem.