### PR TITLE
Skip patches when PatchObsolete/PatchNotBefore is used

### DIFF
--- a/src/CommunityPatch/CommunityPatchSubModule.Patching.cs
+++ b/src/CommunityPatch/CommunityPatchSubModule.Patching.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using HarmonyLib;
 using TaleWorlds.Core;
+using static CommunityPatch.PatchApplicabilityHelper;
 
 namespace CommunityPatch {
 
@@ -25,7 +26,7 @@ namespace CommunityPatch {
         }
 
         try {
-          if (patch.IsApplicable(game) ?? false)
+          if (!IsPatchObsolete(patch) && IsPatchForGameVersion(patch) && (patch.IsApplicable(game) ?? false))
             try {
               patch.Apply(game);
             }
@@ -38,10 +39,11 @@ namespace CommunityPatch {
         }
 
         var patchApplied = patch.Applied;
+        
         if (patchApplied)
           ActivePatches[patch.GetType()] = patch;
 
-        ShowMessage($"{(patchApplied ? "Applied" : "Skipped")} Patch: {patch.GetType().Name}");
+        ShowMessage($"{(patchApplied ? "Applied" : SkippedPatchReason(patch))} Patch: {patch.GetType().Name}");
       }
     }
 

--- a/src/CommunityPatch/PatchApplicabilityHelper.cs
+++ b/src/CommunityPatch/PatchApplicabilityHelper.cs
@@ -7,6 +7,29 @@ namespace CommunityPatch {
 
   public static class PatchApplicabilityHelper {
 
+    private static readonly ApplicationVersionComparer VersionComparer = new ApplicationVersionComparer();
+    
+    public static String SkippedPatchReason(IPatch patch) {
+      var reason = "Skipped";
+      if (IsPatchObsolete(patch))
+        reason = "Obsolete";
+      if (!IsPatchForGameVersion(patch))
+        reason = "Non compatible";
+      return reason;
+    }
+    
+    public static bool IsPatchObsolete(IPatch patch) {
+      var obsolete = patch.GetType().GetCustomAttribute<PatchObsoleteAttribute>();
+      var gameVersion = CommunityPatchSubModule.GameVersion;
+      return obsolete != null && VersionComparer.Compare(gameVersion, obsolete.Version) >= 0;
+    }
+    
+    public static bool IsPatchForGameVersion(IPatch patch) {
+      var notBefore = patch.GetType().GetCustomAttribute<PatchNotBeforeAttribute>();
+      var gameVersion = CommunityPatchSubModule.GameVersion;
+      return !(notBefore != null && VersionComparer.Compare(gameVersion, notBefore.Version) < 0);
+    }
+    
     public static bool IsTargetPatchable(MethodInfo targetMethodInfo, byte[][] targetHashes) {
       if (targetMethodInfo == null)
         return false;

--- a/src/CommunityPatch/PatchApplicabilityHelper.cs
+++ b/src/CommunityPatch/PatchApplicabilityHelper.cs
@@ -1,13 +1,15 @@
 using System;
 using System.Reflection;
 using HarmonyLib;
+using TaleWorlds.Library;
 using static CommunityPatch.HarmonyHelpers;
 
 namespace CommunityPatch {
 
   public static class PatchApplicabilityHelper {
 
-    private static readonly ApplicationVersionComparer VersionComparer = new ApplicationVersionComparer();
+    private static readonly ApplicationVersionComparer VersionComparer = CommunityPatchSubModule.VersionComparer;
+    private static readonly ApplicationVersion GameVersion = CommunityPatchSubModule.GameVersion;
     
     public static String SkippedPatchReason(IPatch patch) {
       var reason = "Skipped";
@@ -20,14 +22,12 @@ namespace CommunityPatch {
     
     public static bool IsPatchObsolete(IPatch patch) {
       var obsolete = patch.GetType().GetCustomAttribute<PatchObsoleteAttribute>();
-      var gameVersion = CommunityPatchSubModule.GameVersion;
-      return obsolete != null && VersionComparer.Compare(gameVersion, obsolete.Version) >= 0;
+      return obsolete != null && VersionComparer.Compare(GameVersion, obsolete.Version) >= 0;
     }
     
     public static bool IsPatchForGameVersion(IPatch patch) {
       var notBefore = patch.GetType().GetCustomAttribute<PatchNotBeforeAttribute>();
-      var gameVersion = CommunityPatchSubModule.GameVersion;
-      return !(notBefore != null && VersionComparer.Compare(gameVersion, notBefore.Version) < 0);
+      return !(notBefore != null && VersionComparer.Compare(GameVersion, notBefore.Version) < 0);
     }
     
     public static bool IsTargetPatchable(MethodInfo targetMethodInfo, byte[][] targetHashes) {

--- a/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/BuilderPatch2.cs
+++ b/src/CommunityPatch/Patches/Perks/Intelligence/Engineering/BuilderPatch2.cs
@@ -4,11 +4,13 @@ using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem.SandBox.GameComponents;
+using TaleWorlds.Library;
 using static System.Reflection.BindingFlags;
 using static CommunityPatch.HarmonyHelpers;
 
 namespace CommunityPatch.Patches.Perks.Intelligence.Engineering {
 
+  [PatchNotBefore(ApplicationVersionType.EarlyAccess, 1, 3)]
   public sealed class BuilderPatch2 : PerkPatchBase<BuilderPatch2> {
 
     public override bool Applied { get; protected set; }

--- a/src/CommunityPatch/Patches/Perks/Social/Leadership/DisciplinarianPatch.cs
+++ b/src/CommunityPatch/Patches/Perks/Social/Leadership/DisciplinarianPatch.cs
@@ -2,9 +2,11 @@ using System.Collections.Generic;
 using System.Reflection;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
+using TaleWorlds.Library;
 
 namespace CommunityPatch.Patches.Perks.Social.Leadership {
 
+  [PatchObsolete(ApplicationVersionType.EarlyAccess, 1, 0, 6)]
   public sealed class DisciplinarianPatch : PerkPatchBase<DisciplinarianPatch> {
 
     public override bool Applied { get; protected set; }


### PR DESCRIPTION
BuilderPatch and BuilderPatch2 patches were wrongly applied. BuilderPatch is obsolete since e1.3.0 and was still applied after 1.3.0+.

- Skip patches that have the PatchObsolete / PatchNotBefore attribute and being not applicable to current game version.

- Makes skipped patches clearer with the addition of "Obsolete" or "Non compatible" patch messages instead of "Skipped".